### PR TITLE
Fix array relationships following item rels

### DIFF
--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -287,6 +287,8 @@ const followRelationships = (state, record) => {
         // Convert to an array to keep things DRY
         is_item = true
         rel_data = [ rel_data ]
+      } else {
+        is_item = false
       }
       for (let rel_item of rel_data) {
         let [ type, id ] = getTypeId({ [jvtag]: rel_item })


### PR DESCRIPTION
Hi @mrichar1, thank you for creating this library. I covers a large part of my current use case, but I think I've encountered a bug in one special condition. In my current use case, the object that is received from the server has item relationships as well as array relationships (some 1-to-1, some 1-to-n).

In the `followRelationships` function, `is_item` is set to `false` by default. After a 1-to-1 relationship has been parsed, it is set to `true`. It remains in this state, even if a 1-to-n relationship is parsed after that. This breaks selecting the correct storage format a few lines later:

https://github.com/mrichar1/jsonapi-vuex/blob/master/src/jsonapi-vuex.js#L297-L303

The fix supplied with this PR fixes this, at least for me. I'm sorry I didn't add a unit test, but I'm in a bit of a hurry today. I might be able to add this next week.