### PR TITLE
Fix rels getting into store

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "chai-exclude": "^2.0.1",
     "concurrently": "^4.0.1",
     "eslint": "^5.6.1",
     "eslint-loader": "^2.1.1",
@@ -71,7 +70,7 @@
   },
   "dependencies": {
     "jsonpath": "^1.0.0",
-    "lodash.clone": "^4.5.0",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.merge": "^4.6.1",
     "vue": "^2.5.17",
     "vuex": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "dependencies": {
     "jsonpath": "^1.0.0",
     "lodash.clonedeep": "^4.5.0",
+    "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.1",
     "vue": "^2.5.17",
     "vuex": "^3.0.1"

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import merge from 'lodash.merge';
-import clone from 'lodash.clone';
+import cloneDeep from 'lodash.clonedeep';
 // https://github.com/dchester/jsonpath/issues/89
 import jp from 'jsonpath/jsonpath.min'
 
@@ -378,7 +378,7 @@ const preserveJSON = (data, json) => {
 // Follow relationships and expand them into _jv/rels
 const followRelationships = (state, record) => {
   // Copy item before modifying
-  const data = clone(record, true)
+  const data = cloneDeep(record)
   data[jvtag]['rels'] = {}
   const rel_names = getNested(data, [ jvtag, 'relationships' ]) || {}
   for (let [ rel_name, rel_info ] of Object.entries(rel_names)) {
@@ -397,7 +397,7 @@ const followRelationships = (state, record) => {
         let result = getNested(state, [ type, id ])
         if (result) {
           // Copy rather than ref to avoid circular JSON issues
-          result = clone(result, true)
+          result = cloneDeep(result)
           if (is_item) {
             // Store attrs directly under rel_name
             data[jvtag]['rels'][rel_name] = result

--- a/tests/unit/actions/get.spec.js
+++ b/tests/unit/actions/get.spec.js
@@ -131,7 +131,7 @@ describe("get", function() {
 
     let res = await jm.actions.get(stub_context, "widget")
 
-    expect(res).excludingEvery('_jv').to.deep.equal(norm_record_rels)
+    expect(res).to.deep.eql(norm_record_rels)
   })
 
   it("should handle an empty rels 'data' object", async function() {

--- a/tests/unit/actions/get.spec.js
+++ b/tests/unit/actions/get.spec.js
@@ -131,7 +131,7 @@ describe("get", function() {
 
     let res = await jm.actions.get(stub_context, "widget")
 
-    expect(res).to.deep.eql(norm_record_rels)
+    expect(res).to.deep.equal(norm_record_rels)
   })
 
   it("should handle an empty rels 'data' object", async function() {

--- a/tests/unit/fixtures/widget_2.js
+++ b/tests/unit/fixtures/widget_2.js
@@ -55,7 +55,12 @@ export function normFormat() {
 
 export function normFormatWithRels() {
   const widget = normFormat()
-  widget._jv.rels = { 1: createNormWidget1(), 3: createNormWidget3() }
+  widget._jv.rels = {
+    widgets: {
+      1: createNormWidget1(),
+      3: createNormWidget3()
+    }
+  }
   return widget
 }
 

--- a/tests/unit/jsonapi-vuex.spec.js
+++ b/tests/unit/jsonapi-vuex.spec.js
@@ -1,6 +1,5 @@
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import chaiExclude from 'chai-exclude';
 import sinonChai from 'sinon-chai';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
@@ -31,7 +30,6 @@ import {
 
 chai.use(sinonChai)
 chai.use(chaiAsPromised)
-chai.use(chaiExclude)
 
 // 'global' variables (redefined in beforeEach)
 let jm, clock, stub_context, json_widget_1, json_record, norm_widget_1,
@@ -396,13 +394,14 @@ describe("jsonapi-vuex tests", function() {
         jm = jsonapiModule(api, { 'follow_relationships_data': true })
         const { get } = jm.getters
         const result = get(store_record, { 'get': get })('widget/2')
-        expect(norm_widget_2_rels).excludingEvery('_jv').to.deep.equal(result)
+
+        expect(norm_widget_2_rels).to.deep.equal(result)
       })
       it("should follow relationships data (array) for a collection", function() {
         jm = jsonapiModule(api, { 'follow_relationships_data': true })
         const { get } = jm.getters
         const result = get(store_record, { 'get': get })('widget')
-        expect(norm_record_rels).excludingEvery('_jv').to.deep.equal(result)
+        expect(norm_record_rels).to.deep.equal(result)
       })
     })
 

--- a/tests/unit/jsonapi-vuex.spec.js
+++ b/tests/unit/jsonapi-vuex.spec.js
@@ -394,7 +394,6 @@ describe("jsonapi-vuex tests", function() {
         jm = jsonapiModule(api, { 'follow_relationships_data': true })
         const { get } = jm.getters
         const result = get(store_record, { 'get': get })('widget/2')
-
         expect(norm_widget_2_rels).to.deep.equal(result)
       })
       it("should follow relationships data (array) for a collection", function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2283,13 +2283,6 @@ chai-as-promised@^7.1.1:
   dependencies:
     check-error "^1.0.2"
 
-chai-exclude@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/chai-exclude/-/chai-exclude-2.0.1.tgz#43e474a2a055d5efa414efcae30a91761148809c"
-  integrity sha512-9cZ0ZzlGRwZvNiKUPTbx4E1anQ4aTqtKOX96+cb4XrNa+8B5KNZg3d43clYNawgXgBcQAenXeX5fbeY7+TdkrA==
-  dependencies:
-    fclone "^1.0.11"
-
 chai-nightwatch@~0.1.x:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/chai-nightwatch/-/chai-nightwatch-0.1.1.tgz#1ca56de768d3c0868fe7fc2f4d32c2fe894e6be9"
@@ -4190,11 +4183,6 @@ faye-websocket@~0.11.1:
   integrity sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=
   dependencies:
     websocket-driver ">=0.5.1"
-
-fclone@^1.0.11:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/fclone/-/fclone-1.0.11.tgz#10e85da38bfea7fc599341c296ee1d77266ee640"
-  integrity sha1-EOhdo4v+p/xZk0HClu4ddyZu5kA=
 
 fd-slicer@~1.0.1:
   version "1.0.1"
@@ -6099,10 +6087,10 @@ lodash.clone@3.0.3:
     lodash._bindcallback "^3.0.0"
     lodash._isiterateecall "^3.0.0"
 
-lodash.clone@^4.5.0:
+lodash.clonedeep@^4.5.0:
   version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
-  integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
 lodash.create@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Fixes https://github.com/mrichar1/jsonapi-vuex/issues/32

The issue was essentially that using a shallow clone was allowing the `rels` key to end up in the store. Then subsequently calling post or patch would error due to a cyclical reference.

The fact that I previously had to use `excludingEvery('_jv')` in the tests should have indicated to me the issue. Removing `excludingEvery('_jv')` caused the test to fail revealing the bug. Then adding `cloneDeep` fixed the bug.