### PR TITLE
Delete rels from payload to server

### DIFF
--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -491,7 +491,10 @@ const normToJsonapiItem = (data) => {
   // Fastest way to deep copy
   const jsonapi = { ...data[jvtag] }
   jsonapi['attributes'] = Object.assign({}, data)
+
+  delete jsonapi.rels
   delete jsonapi['attributes'][jvtag]
+
   return jsonapi
 }
 

--- a/tests/unit/actions/patch.spec.js
+++ b/tests/unit/actions/patch.spec.js
@@ -8,6 +8,7 @@ import {
   normFormat as createNormWidget1,
   normFormatPatch as createNormWidget1Patch,
   normFormatUpdate as createNormWidget1Update,
+  normFormatWithRels as createNormWidget1WithRels,
 } from '../fixtures/widget_1';
 import {
   createResponseMeta
@@ -90,5 +91,14 @@ describe("patch", function() {
     } catch (error) {
       expect(error.response.status).to.equal(500)
     }
+  })
+
+  it("should not include rels in requests", async function() {
+    this.mock_api.onAny().reply(204)
+    const widget = createNormWidget1WithRels()
+
+    await jsonapiModule.actions.patch(stub_context, widget)
+
+    expect(JSON.parse(this.mock_api.history.patch[0].data)).to.deep.equal({ data: json_widget_1 })
   })
 })


### PR DESCRIPTION
Sometimes the payload sent to the server might contains the `rels` key. For me this occurs because I use the return value from the promise of a `post` or `patch` action to make subsequent requests.