### PR TITLE
addJVHelpers utility functions added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ A module to access JSONAPI data from an API, using a Vuex store, restructured to
 ## Features
 
 - Creates a [Vuex](https://vuex.vuejs.org/) module to store API data.
-- High-level methods to wrap common RESTful operations (GET, POST, PUT, DELETE).
-- Restructures/normalizes data, making record handling easier.
-- Makes fetching related objects easy.
-- Relationships can be followed and expanded into records automatically (recursively).
+- High-level methods to wrap common RESTful operations (GET, POST, PUT, DELETE). (See [Actions](#actions))
+- Restructures/normalizes data, making record handling easier. (See [Restructured Data](#restructured-data))
+- Makes fetching related objects easy. (See [getRelated](#getrelated))
+- Relationships can be followed and expanded into records automatically (recursively). (See [Related Items](#related-items))
 - Uses [Axios](https://github.com/axios/axios) (or your own axios-like module) as the HTTP client.
 - Uses [jsonpath](https://github.com/dchester/jsonpath) for filtering when getting objects from the store.
 - Records the status of actions (LOADING, SUCCESS, ERROR).
@@ -50,7 +50,7 @@ The most common way to access the API and update the store is through high-level
 
 The usual way to use this module is to use `actions` wherever possible. All actions are asynchronous, and both query the API and update the store, then return data in a normalized form. Every action call's state is tracked as it progresses, and this status can be easily queried (see the `status` getter).
 
-There are 4 actions (with aliases): `get` (`fetch`), `post` (`create`), `patch` (`update`), and `delete` which correspond to RESTful methods. There is also a `getRelated` action which fetches a record's related items.
+There are 4 actions (with aliases): `get` (`fetch`), `post` (`create`), `patch` (`update`), and `delete` which correspond to RESTful methods. There is also a [getRelated](#getrelated) action which fetches a record's [related items](#related-items).
 
 #### RESTful actions
 
@@ -98,11 +98,11 @@ this.$store.dispatch('jv/post', [newWidget, {params: params}])
 
 #### getRelated
 
-_Note_ - in many cases you may prefer to use the jsonapi server-side `include` option to get data on relationships included in your original query. (See `Related Items`).
+_Note_ - in many cases you may prefer to use the jsonapi server-side `include` option to get data on relationships included in your original query. (See [Related Items](#related-items)).
 
 Like the RESTful actions, this takes 2 arguments - the URL/object to be acted on, and an axios config object. It returns a deeply nested restructured tree - `relationship -> type -> id -> data`.
 
-_Note_ - `getRelated` only works on specific items, not collections.
+_Note_ - [getRelated](#getrelated) only works on specific items, not collections.
 
 ```
 // Assuming the API holds the following data
@@ -233,13 +233,13 @@ For example, you might want to disable an attribute while an action is happening
 <input type="text" :disabled="status == 'LOADING'">
 ```
 
-### Related items
+### Related Items
 
-By default the `get` action and getter are both configured to follow and expand out relationships recursively, if they are provided as `data` entries (i.e. `{type: 'widget', id: '1'}`).
+By default the `get` action and getter are both configured to follow and expand out relationships recursively, if they are provided as `data` entries (i.e. `{type: 'widget', id: '1'}`). This behaviour is controlled with the `followRelationshipsData` config option.
 
 _Note_ - If using the `action` you may wish to also set the `include` parameter on the server query to include the relationships you are interested in. Any records returned in the `included` section of the jsonapi data will be automatically added to the store.
 
-For any relationships where the related item is already in the store, this is added to the returned object(s) in `obj['_jv']['rels'][relName]`. For items with a single relationship, the object is placed directly under the `relName` - for mutiple items, they are indexed by id:
+For any relationships where the related item is already in the store, this is added to the returned object(s) in the 'root', alongside the `attributes`. For items with a single relationship, the object is placed directly under the `relName` - for mutiple items, they are indexed by id:
 
 ```
 // Assuming the store is as follows:
@@ -264,9 +264,11 @@ store = {
   }
 }
 
-// Get widget/1, with related items in _jv/rels... either:
+// Get widget/1, with related items
 
-// (note the use of include to ensure `parts` is in the store)
+// Either:
+
+// (Note the use of include to ensure `parts` is in the store)
 let item1 = await this.$store.dispatch('jv/get', 'widget/1', [{include: 'parts'}])
 
 // OR...
@@ -275,26 +277,40 @@ let item1 = this.$store.getters['jv/get']('widget/1')
 
 // This will return:
 {
-  name: 'sprocket',
+  'name': 'sprocket',
+  'parts': {
+    'name': 'cog'
+    '_jv': { ... }
+  }
   '_jv': {
     'id': '1',
     'type': 'widget',
-    'rels': {
-      'parts': {
-        'name': 'cog'
-        '_jv': { ... }
-        }
-      }
-    }
   }
 }
 
-// This can then be accessed as:
-item1._jv.rels.parts.name
 
-//  Or if there were multiple related items as:
-item1._jv.rels.parts.2.name
+```
 
+## Helper Functions
+
+Distinguishing between the `attributes` and `relationships` in the 'root' is simplified by a number of 'helper' functions which are provided in the `_jv` (`jvtag`) object:
+
+- `attrs` - a getter property which returns an object containing all attributes.
+
+- `rels` - a getter property which returns an object containing all relationships.
+
+- `isAttr` - a function which returns True/False for a given name.
+
+- `isRel` - a function which returns True/False for a given name.
+
+These are particularly useful in `Vue` templates. For example to iterate over an item, picking out just the attributes:
+
+```
+<li v-for="(val, key) in widget._jv.attrs">{{ key }} {{ val }}</li>
+
+<!-- Or -->
+
+<li v-for="(val, key) in widget" v-if="widget._jv.isAttr(key)">{{ key }} {{ val }}</li>
 ```
 
 ## Configuration
@@ -309,7 +325,7 @@ jm = jsonapiModule(api, config)
 ### Config Options
 
 - `jvtag` - The tag in restructured objects to hold object metadata (defaults to `_jv`)
-- `followRelationshipsData` - Whether to follow and expand relationships from the store in the `get` getter (defaults to `true`)
+- `followRelationshipsData` - Whether to follow and expand relationships and store them alongside attribrutes in the item 'root' (defaults to `true`)
 - `preserveJson` - Whether actions should return the API response json (minus `data`) in `_jv/json` (for access to meta etc) (defaults to `false`)
 - `actionStatusCleanAge` - What age must action status records be before they are removed (defaults to 600 seconds). Set to `0` to disable.
 

--- a/examples/testapp/src/components/JsonapiVuex.vue
+++ b/examples/testapp/src/components/JsonapiVuex.vue
@@ -20,7 +20,7 @@
       </div>
       <h3>Related</h3>
       <div v-if="'_jv' in widget1 && 'rels' in widget1['_jv']">
-        <div :id='"rels_" + name' v-for="(rel, name, index) in widget1['_jv']['rels']" :key="index">
+        <div :id='"rels_" + name' v-for="(rel, name, index) in widget1" v-if="widget1['_jv'].isRel(name)" :key="index">
           <span>Related: </span>
           <span :id='"rel_span_relname"'>{{ name }}</span>&nbsp;
           <span :id='"rel_span_name"'>{{ rel.name }}</span>&nbsp;
@@ -30,7 +30,7 @@
     </div>
     <div id="patch">
       <h2>Patch widget 1</h2>
-      <div v-for="(value, name, index) in widget1" :key="index" v-if="name != '_jv'">
+      <div v-for="(value, name, index) in widget1" :key="index" v-if="widget1._jv.isAttr(name)">
         <label :for='"patch_" + name'>{{ name }}</label>
         <input :id='"patch_" + name' v-model="widget1[name]"/>
       </div>

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -558,12 +558,19 @@ const jsonapiToNorm = (data) => {
 
 // Denormalize an item to jsonapi
 const normToJsonapiItem = (data) => {
-  // Fastest way to deep copy
-  const jsonapi = { ...data[jvtag] }
-  jsonapi['attributes'] = Object.assign({}, data)
-
-  delete jsonapi.rels
-  delete jsonapi['attributes'][jvtag]
+  const jsonapi = {}
+  //Pick out expected resource members, if they exist
+  for (let member of ['id', 'type', 'relationships', 'meta', 'links']) {
+    if (data[jvtag].hasOwnProperty(member)) {
+      jsonapi[member] = data[jvtag][member]
+    }
+  }
+  if (jvConfig.followRelationshipsData) {
+    jsonapi['attributes'] = data[jvtag].attrs
+  } else {
+    jsonapi['attributes'] = Object.assign({}, data)
+    delete jsonapi['attributes'][jvtag]
+  }
 
   return jsonapi
 }
@@ -617,6 +624,7 @@ const _testing = {
   followRelationships: followRelationships,
   jvConfig: jvConfig,
   RecordError: RecordError,
+  addJvHelpers: addJvHelpers,
 }
 
 // Export this module

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -371,7 +371,7 @@ const addJvHelpers = (obj) => {
       return get(obj, [jvtag, 'relationships'], {}).hasOwnProperty(name)
     },
     isAttr(name) {
-      return name !== jvtag && !this.isRel(name)
+      return name !== jvtag && obj.hasOwnProperty(name) && !this.isRel(name)
     },
   })
   // Use defineProperty as assign copies the values, not the getter function

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -363,12 +363,12 @@ const addJvHelpers = (obj) => {
   // Add Utility functions to _jv child object
   Object.assign(obj[jvtag], {
     isRel(name) {
-      return obj[jvtag]['relationships'].hasOwnProperty(name)
+      return get(obj, [jvtag, 'relationships'], {}).hasOwnProperty(name)
     },
     isAttr(name) {
       return name !== jvtag && !this.isRel(name)
     },
-    get rels() {
+    rels() {
       const rel = {}
       for (let [key, val] of Object.entries(obj)) {
         if (this.isRel(key)) {
@@ -377,7 +377,7 @@ const addJvHelpers = (obj) => {
       }
       return rel
     },
-    get attrs() {
+    attrs() {
       const att = {}
       for (let [key, val] of Object.entries(obj)) {
         if (key !== jvtag && !this.isRel(key)) {
@@ -565,8 +565,9 @@ const normToJsonapiItem = (data) => {
       jsonapi[member] = data[jvtag][member]
     }
   }
-  if (jvConfig.followRelationshipsData) {
-    jsonapi['attributes'] = data[jvtag].attrs
+  // User-generated data (e.g. post) has no helper methods
+  if (data[jvtag].hasOwnProperty('attrs') && jvConfig.followRelationshipsData) {
+    jsonapi['attributes'] = data[jvtag].attrs()
   } else {
     jsonapi['attributes'] = Object.assign({}, data)
     delete jsonapi['attributes'][jvtag]

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -362,16 +362,16 @@ const jsonapiModule = (api, conf = {}) => {
 const addJvHelpers = (obj) => {
   // Add Utility functions to _jv child object
   Object.assign(obj[jvtag], {
-    is_rel(name) {
-      return name in obj[jvtag]['relationships']
+    isRel(name) {
+      return obj[jvtag]['relationships'].hasOwnProperty(name)
     },
-    is_attr(name) {
-      return name != '_jv' && !this.is_rel(name)
+    isAttr(name) {
+      return name !== '_jv' && !this.isRel(name)
     },
     get rels() {
       const rel = {}
       for (let [key, val] of Object.entries(obj)) {
-        if (key in obj[jvtag]['relationships']) {
+        if (obj[jvtag]['relationships'].hasOwnProperty(key)) {
           rel[key] = val
         }
       }
@@ -380,7 +380,7 @@ const addJvHelpers = (obj) => {
     get attrs() {
       const att = {}
       for (let [key, val] of Object.entries(obj)) {
-        if (key != jvtag && !(key in obj[jvtag]['relationships'])) {
+        if (key != jvtag && !(obj[jvtag]['relationships'].hasOwnProperty(key))) {
           att[key] = val
         }
       }

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -371,7 +371,7 @@ const addJvHelpers = (obj) => {
     get rels() {
       const rel = {}
       for (let [key, val] of Object.entries(obj)) {
-        if (obj[jvtag]['relationships'].hasOwnProperty(key)) {
+        if (this.isRel(key)) {
           rel[key] = val
         }
       }
@@ -380,7 +380,7 @@ const addJvHelpers = (obj) => {
     get attrs() {
       const att = {}
       for (let [key, val] of Object.entries(obj)) {
-        if (key != jvtag && !obj[jvtag]['relationships'].hasOwnProperty(key)) {
+        if (key !== jvtag && !this.isRel(key)) {
           att[key] = val
         }
       }

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -366,7 +366,7 @@ const addJvHelpers = (obj) => {
       return obj[jvtag]['relationships'].hasOwnProperty(name)
     },
     isAttr(name) {
-      return name !== '_jv' && !this.isRel(name)
+      return name !== jvtag && !this.isRel(name)
     },
     get rels() {
       const rel = {}
@@ -380,7 +380,7 @@ const addJvHelpers = (obj) => {
     get attrs() {
       const att = {}
       for (let [key, val] of Object.entries(obj)) {
-        if (key != jvtag && !(obj[jvtag]['relationships'].hasOwnProperty(key))) {
+        if (key != jvtag && !obj[jvtag]['relationships'].hasOwnProperty(key)) {
           att[key] = val
         }
       }

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -302,9 +302,14 @@ const getters = (/* api */) => {
         const [type, id] = getTypeId(data)
 
         if (type in state) {
-          if (id && id in state[type]) {
-            // single item
-            result = state[type][id]
+          if (id) {
+            if (state[type].hasOwnProperty(id)) {
+              // single item
+              result = state[type][id]
+            } else {
+              // No item of that type
+              return {}
+            }
           } else {
             // whole collection, indexed by id
             result = state[type]

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -452,7 +452,7 @@ const followRelationships = (state, record, followState) => {
   }
 
   // Copy item before modifying
-  const data = addJvHelpers(cloneDeep(record))
+  const data = cloneDeep(record)
 
   // Store cloned object in followState for future reuse during recursion
   followState[recordType][recordId] = data
@@ -486,7 +486,7 @@ const followRelationships = (state, record, followState) => {
       }
     }
   }
-  return data
+  return addJvHelpers(data)
 }
 
 // Make sure args is always an array of data and config

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -374,6 +374,8 @@ const addJvHelpers = (obj) => {
       return name !== jvtag && !this.isRel(name)
     },
   })
+  // Use defineProperty as assign copies the values, not the getter function
+  // https://github.com/mrichar1/jsonapi-vuex/pull/40#issuecomment-474560508
   Object.defineProperty(obj[jvtag], 'rels', {
     get() {
       const rel = {}

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -601,17 +601,21 @@ const normToJsonapi = (record) => {
 // Convert a norm record to store format
 const normToStore = (record) => {
   let store = {}
-  if (!(jvtag in record)) {
-    for (let item of Object.values(record)) {
-      const { type, id } = item[jvtag]
-      if (!(type in store)) {
-        store[type] = {}
-      }
-      store[type][id] = item
+  if (jvtag in record) {
+    // Convert item to look like a collection
+    record = { [record[jvtag]['id']]: record }
+  }
+  for (let item of Object.values(record)) {
+    const { type, id } = item[jvtag]
+    if (!(type in store)) {
+      store[type] = {}
     }
-  } else {
-    const { type, id } = record[jvtag]
-    store = { [type]: { [id]: record } }
+    if (jvConfig.followRelationshipsData) {
+      for (let rel in item[jvtag].rels) {
+        delete item[rel]
+      }
+    }
+    store[type][id] = item
   }
   return store
 }

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -368,7 +368,9 @@ const addJvHelpers = (obj) => {
     isAttr(name) {
       return name !== jvtag && !this.isRel(name)
     },
-    rels() {
+  })
+  Object.defineProperty(obj[jvtag], 'rels', {
+    get() {
       const rel = {}
       for (let [key, val] of Object.entries(obj)) {
         if (this.isRel(key)) {
@@ -377,7 +379,9 @@ const addJvHelpers = (obj) => {
       }
       return rel
     },
-    attrs() {
+  })
+  Object.defineProperty(obj[jvtag], 'attrs', {
+    get() {
       const att = {}
       for (let [key, val] of Object.entries(obj)) {
         if (key !== jvtag && !this.isRel(key)) {
@@ -567,7 +571,7 @@ const normToJsonapiItem = (data) => {
   }
   // User-generated data (e.g. post) has no helper methods
   if (data[jvtag].hasOwnProperty('attrs') && jvConfig.followRelationshipsData) {
-    jsonapi['attributes'] = data[jvtag].attrs()
+    jsonapi['attributes'] = data[jvtag].attrs
   } else {
     jsonapi['attributes'] = Object.assign({}, data)
     delete jsonapi['attributes'][jvtag]

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -124,7 +124,7 @@ const actions = (api) => {
       let action = context
         .dispatch('get', args)
         .then((record) => {
-          let rels = get(record, [jvtag, 'relationships']) || {}
+          let rels = get(record, [jvtag, 'relationships'], {})
           if (relName && rels) {
             // Only process requested relname
             rels = { [relName]: rels[relName] }
@@ -461,7 +461,7 @@ const followRelationships = (state, record, followState) => {
   // Store cloned object in followState for future reuse during recursion
   followState[recordType][recordId] = data
 
-  const relNames = get(data, [jvtag, 'relationships']) || {}
+  const relNames = get(data, [jvtag, 'relationships'], {})
   for (let [relName, relInfo] of Object.entries(relNames)) {
     let isItem = false
     // We can only work with data, not links since we need type & id

--- a/tests/unit/actions/get.spec.js
+++ b/tests/unit/actions/get.spec.js
@@ -147,7 +147,7 @@ describe('get', function() {
 
     let res = await jm.actions.get(stubContext, normWidget1)
 
-    expect(res).to.deep.equal(normWidget1_rels)
+    expect(res).to.have.all.keys(normWidget1_rels)
   })
 
   it('should return normalized data with expanded rels (array)', async function() {
@@ -160,7 +160,10 @@ describe('get', function() {
 
     let res = await jm.actions.get(stubContext, 'widget')
 
-    expect(res).to.deep.equal(normRecordRels)
+    // Check 'sub-key' equality for each item in the collection
+    for (let [key, val] of Object.entries(res)) {
+      expect(val).to.have.all.keys(normRecordRels[key])
+    }
   })
 
   it("should handle an empty rels 'data' object", async function() {

--- a/tests/unit/actions/patch.spec.js
+++ b/tests/unit/actions/patch.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
 
+import { _testing } from '../../../src/jsonapi-vuex'
 import createStubContext from '../stubs/context'
 import createJsonapiModule from '../utils/createJsonapiModule'
 import {
@@ -111,9 +112,11 @@ describe('patch', function() {
   })
 
   it('should not include rels in requests', async function() {
+    const { addJvHelpers } = _testing
     this.mockApi.onAny().reply(204)
-    const widget = createNormWidget1WithRels()
-
+    // Helper functions needed for attrs() call in normtoJsonapi() in patch()
+    const widget = addJvHelpers(createNormWidget1WithRels())
+    jsonapiModule = createJsonapiModule(this.api, {followRelationshipsData: true}) //prettier-ignore
     await jsonapiModule.actions.patch(stubContext, widget)
 
     expect(JSON.parse(this.mockApi.history.patch[0].data)).to.deep.equal({

--- a/tests/unit/fixtures/record.js
+++ b/tests/unit/fixtures/record.js
@@ -40,12 +40,12 @@ export function normFormatWithRels() {
   const normWidget2_rels = createNormWidget2WithRels()
   const normWidget3_rels = createNormWidget3WithRels()
 
-  normWidget1_rels._jv.rels.widgets = normWidget2_rels
-  normWidget2_rels._jv.rels.widgets = {
+  normWidget1_rels.widgets = normWidget2_rels
+  normWidget2_rels.widgets = {
     [normWidget1_rels['_jv']['id']]: normWidget1_rels,
     [normWidget3_rels['_jv']['id']]: normWidget3_rels,
   }
-  normWidget3_rels._jv.rels.widgets = normWidget1_rels
+  normWidget3_rels.widgets = normWidget1_rels
 
   return {
     [normWidget1_rels['_jv']['id']]: normWidget1_rels,

--- a/tests/unit/fixtures/widget1.js
+++ b/tests/unit/fixtures/widget1.js
@@ -68,7 +68,7 @@ export function normFormat() {
 
 export function normFormatWithRels() {
   const widget = normFormat()
-  widget._jv.rels = { widgets: createNormWidget2() }
+  Object.assign(widget, { widgets: createNormWidget2() })
   return widget
 }
 

--- a/tests/unit/fixtures/widget2.js
+++ b/tests/unit/fixtures/widget2.js
@@ -51,12 +51,12 @@ export function normFormat() {
 
 export function normFormatWithRels() {
   const widget = normFormat()
-  widget._jv.rels = {
+  Object.assign(widget, {
     widgets: {
       1: createNormWidget1(),
       3: createNormWidget3(),
     },
-  }
+  })
   return widget
 }
 

--- a/tests/unit/fixtures/widget3.js
+++ b/tests/unit/fixtures/widget3.js
@@ -38,7 +38,7 @@ export function normFormat() {
 
 export function normFormatWithRels() {
   const widget = normFormat()
-  widget._jv.rels = { widgets: createNormWidget1() }
+  Object.assign(widget, { widgets: createNormWidget1() })
   return widget
 }
 

--- a/tests/unit/jsonapi-vuex.spec.js
+++ b/tests/unit/jsonapi-vuex.spec.js
@@ -292,6 +292,14 @@ describe('jsonapi-vuex tests', function() {
         const { normToJsonapiItem } = _testing
         expect(normToJsonapiItem(normWidget1)).to.deep.equal(jsonWidget1)
       })
+      it('should convert normalized to jsonapi with root rels', function() {
+        jm = jsonapiModule(api, { followRelationshipsData: true })
+        const { normToJsonapiItem } = _testing
+        const { addJvHelpers } = _testing
+        // Add JvHelper methods to object
+        normWidget1_rels = addJvHelpers(normWidget1_rels)
+        expect(normToJsonapiItem(normWidget1_rels)).to.deep.equal(jsonWidget1)
+      })
       it('should convert normalized to jsonapi for a single item with no id (POST)', function() {
         const { normToJsonapiItem } = _testing
         delete normWidget1['_jv']['id']

--- a/tests/unit/jsonapi-vuex.spec.js
+++ b/tests/unit/jsonapi-vuex.spec.js
@@ -294,8 +294,7 @@ describe('jsonapi-vuex tests', function() {
       })
       it('should convert normalized to jsonapi with root rels', function() {
         jm = jsonapiModule(api, { followRelationshipsData: true })
-        const { normToJsonapiItem } = _testing
-        const { addJvHelpers } = _testing
+        const { normToJsonapiItem, addJvHelpers } = _testing
         // Add JvHelper methods to object
         normWidget1Rels = addJvHelpers(normWidget1Rels)
         expect(normToJsonapiItem(normWidget1Rels)).to.deep.equal(jsonWidget1)

--- a/tests/unit/jsonapi-vuex.spec.js
+++ b/tests/unit/jsonapi-vuex.spec.js
@@ -316,6 +316,20 @@ describe('jsonapi-vuex tests', function() {
         const { normToStore } = _testing
         expect(normToStore(normWidget1)).to.deep.equal(storeWidget1)
       })
+      it('should convert normalized item to store, removing rels from root', function() {
+        const { normToStore, addJvHelpers } = _testing
+        jm = jsonapiModule(api, { followRelationshipsData: true })
+        normWidget1Rels = addJvHelpers(normWidget1Rels)
+        expect(normToStore(normWidget1Rels)).to.have.all.keys(storeWidget1)
+      })
+      it('should convert normalized records to store, removing rels from root', function() {
+        const { normToStore, addJvHelpers } = _testing
+        jm = jsonapiModule(api, { followRelationshipsData: true })
+        for (let item of Object.values(normRecordRels)) {
+          item = addJvHelpers(item)
+        }
+        expect(normToStore(normRecordRels)).to.have.all.keys(storeRecord)
+      })
     })
     describe('unpackArgs', function() {
       it('Should convert a single arg into an array with empty config', function() {

--- a/tests/unit/jsonapi-vuex.spec.js
+++ b/tests/unit/jsonapi-vuex.spec.js
@@ -392,6 +392,20 @@ describe('jsonapi-vuex tests', function() {
         })
         expect(result).to.deep.equal(normWidget1)
       })
+      it('should return nothing for a non-existent type', function() {
+        const { get } = jm.getters
+        const result = get(storeWidget1)({
+          _jv: { type: 'nosuchtype' },
+        })
+        expect(result).to.deep.equal({})
+      })
+      it('should return nothing for a non-existent id', function() {
+        const { get } = jm.getters
+        const result = get(storeWidget1)({
+          _jv: { type: 'widget', id: '999' },
+        })
+        expect(result).to.deep.equal({})
+      })
       it('should accept a string path to object', function() {
         const { get } = jm.getters
         const result = get(storeWidget1)('widget/1')

--- a/tests/unit/jsonapi-vuex.spec.js
+++ b/tests/unit/jsonapi-vuex.spec.js
@@ -366,6 +366,50 @@ describe('jsonapi-vuex tests', function() {
         expect(stubContext.commit).to.have.been.calledWith('deleteStatus')
       })
     })
+
+    describe('addJvHelpers', function() {
+      beforeEach(function() {
+        // Apply helper functions to normWidget1
+        const { addJvHelpers } = _testing
+        normWidget1 = addJvHelpers(normWidget1)
+        normWidget1Rels = addJvHelpers(normWidget1Rels)
+      })
+      it('Should add methods to an objects _jv object', function() {
+        expect(normWidget1['_jv']).to.include.keys(
+          // 'attrs',
+          // 'rels',
+          'isAttr',
+          'isRel'
+        )
+        // Keys doesn't count getter functions, so test separately
+        expect(normWidget1['_jv']).to.have.property('attrs')
+        expect(normWidget1['_jv']).to.have.property('rels')
+      })
+      it('Should list all object attributes', function() {
+        const attrs = normWidget1['_jv'].attrs
+        // throw away all but attrs
+        delete normWidget1['_jv']
+        expect(attrs).to.have.all.keys(normWidget1)
+      })
+      it('Should list all object rels', function() {
+        const rels = normWidget1Rels['_jv'].rels
+        expect(rels).to.have.all.keys(normWidget1Rels['_jv']['relationships'])
+      })
+      it('Should return true/false with isAttr', function() {
+        for (let attr of Object.keys(normWidget1)) {
+          if (attr !== '_jv') {
+            expect(normWidget1['_jv'].isAttr(attr)).to.be.true
+          }
+        }
+        expect(normWidget1['_jv'].isAttr('no_such_attr')).to.be.false
+      })
+      it('Should return true/false with isRel', function() {
+        for (let rel of Object.keys(normWidget1['_jv']['relationships'])) {
+          expect(normWidget1['_jv'].isRel(rel)).to.be.true
+        }
+        expect(normWidget1['_jv'].isRel('no_such_rel')).to.be.false
+      })
+    })
   }) // Helper methods
 
   describe('jsonapiModule getters', function() {

--- a/tests/unit/jsonapi-vuex.spec.js
+++ b/tests/unit/jsonapi-vuex.spec.js
@@ -330,10 +330,11 @@ describe('jsonapi-vuex tests', function() {
     })
 
     describe('followRelationships', function() {
-      it('Should expand relationships into rels for a single item', function() {
+      it('Should expand relationships into root for a single item', function() {
         const { followRelationships } = _testing
-        let rels = followRelationships(storeRecord, normWidget1)['_jv']['rels']['widgets'] // prettier-ignore
-        expect(rels).to.deep.equal(normWidget2_rels)
+        let rels = followRelationships(storeRecord, normWidget1)
+        // Object is recursive so only compare top-level keys
+        expect(rels['widgets']).to.have.all.keys(normWidget2_rels)
       })
     })
 
@@ -417,19 +418,22 @@ describe('jsonapi-vuex tests', function() {
         jm = jsonapiModule(api, { followRelationshipsData: true })
         const { get } = jm.getters
         const result = get(storeRecord, { get: get })('widget/1')
-        expect(normWidget1_rels).to.deep.equal(result)
+        expect(result).to.have.all.keys(normWidget1_rels)
       })
       it('should follow relationships data (array)', function() {
         jm = jsonapiModule(api, { followRelationshipsData: true })
         const { get } = jm.getters
         const result = get(storeRecord, { get: get })('widget/2')
-        expect(normWidget2_rels).to.deep.equal(result)
+        expect(result).to.have.all.keys(normWidget2_rels)
       })
       it('should follow relationships data (array) for a collection', function() {
         jm = jsonapiModule(api, { followRelationshipsData: true })
         const { get } = jm.getters
         const result = get(storeRecord, { get: get })('widget')
-        expect(normRecordRels).to.deep.equal(result)
+        // Check 'sub-key' equality for each item in the collection
+        for (let [key, val] of Object.entries(result)) {
+          expect(val).to.have.all.keys(normRecordRels[key])
+        }
       })
     })
 


### PR DESCRIPTION
Fixes #23 

Code adds utility functions to an existing object's `_jv` child object to allow `rels` and `attrs` introspection, as suggested in #23.

Tests are failing (as the root now contains relationships! :smile: ) so the test data will need modified to expect these.

@staam let me know if this looks like what you were thinking of, and if so I'll update the tests(and add new ones for`addJvHelpers` (which probably needs a better name!)

