### PR TITLE
Refactor axios to allow more config overrides.

### DIFF
--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -68,12 +68,13 @@ const actions = (api) => {
     get: (context, args) => {
       const [data, config] = unpackArgs(args)
       const path = getURL(data)
+      const apiConf = { method: 'get', url: path }
       // https://github.com/axios/axios/issues/362
       config['data'] = config['data'] || {}
+      merge(apiConf, config)
       const actionId = actionSequence(context)
       context.commit('setStatus', { id: actionId, status: STATUS_LOAD })
-      let action = api
-        .get(path, config)
+      let action = api(apiConf)
         .then((results) => {
           processIncludedRecords(context, results)
 
@@ -185,10 +186,11 @@ const actions = (api) => {
     post: (context, args) => {
       let [data, config] = unpackArgs(args)
       const path = getURL(data, true)
+      const apiConf = { method: 'post', url: path, data: normToJsonapi(data) }
+      merge(apiConf, config)
       const actionId = actionSequence(context)
       context.commit('setStatus', { id: actionId, status: STATUS_LOAD })
-      let action = api
-        .post(path, normToJsonapi(data), config)
+      let action = api(apiConf)
         .then((results) => {
           processIncludedRecords(context, results)
 
@@ -215,9 +217,10 @@ const actions = (api) => {
       let [data, config] = unpackArgs(args)
       const path = getURL(data)
       const actionId = actionSequence(context)
+      const apiConf = { method: 'patch', url: path, data: normToJsonapi(data) }
+      merge(apiConf, config)
       context.commit('setStatus', { id: actionId, status: STATUS_LOAD })
-      let action = api
-        .patch(path, normToJsonapi(data), config)
+      let action = api(apiConf)
         .then((results) => {
           // If the server handed back data, store it
           if (results.status === 200) {
@@ -249,10 +252,11 @@ const actions = (api) => {
     delete: (context, args) => {
       const [data, config] = unpackArgs(args)
       const path = getURL(data)
+      const apiConf = { method: 'delete', url: path }
+      merge(apiConf, config)
       const actionId = actionSequence(context)
       context.commit('setStatus', { id: actionId, status: STATUS_LOAD })
-      let action = api
-        .delete(path, config)
+      let action = api(apiConf)
         .then((results) => {
           processIncludedRecords(context, results)
 

--- a/tests/unit/actions/delete.spec.js
+++ b/tests/unit/actions/delete.spec.js
@@ -37,7 +37,15 @@ describe('delete', function() {
       { params: params },
     ])
 
-    expect(this.mockApi.history.delete[0].params).to.equal(params)
+    expect(this.mockApi.history.delete[0].params).to.deep.equal(params)
+  })
+
+  it('should allow the endpoint url to be overridden in config', async function() {
+    this.mockApi.onAny().reply(200, { data: jsonWidget1 })
+    const url = '/fish/1'
+
+    await jsonapiModule.actions.delete(stubContext, [normWidget1, { url: url }])
+    expect(this.mockApi.history.delete[0].url).to.equal(url)
   })
 
   it('should delete a record from the store', async function() {

--- a/tests/unit/actions/get.spec.js
+++ b/tests/unit/actions/get.spec.js
@@ -81,8 +81,15 @@ describe('get', function() {
       normWidget1,
       { params: params },
     ])
+    expect(this.mockApi.history.get[0].params).to.deep.equal(params)
+  })
 
-    expect(this.mockApi.history.get[0].params).to.equal(params)
+  it('should allow the endpoint url to be overridden in config', async function() {
+    this.mockApi.onAny().reply(200, { data: jsonWidget1 })
+    const url = '/fish/1'
+
+    await jsonapiModule.actions.get(stubContext, [normWidget1, { url: url }])
+    expect(this.mockApi.history.get[0].url).to.equal(url)
   })
 
   it('should add record(s) in the store', async function() {

--- a/tests/unit/actions/patch.spec.js
+++ b/tests/unit/actions/patch.spec.js
@@ -52,7 +52,15 @@ describe('patch', function() {
       { params: params },
     ])
 
-    expect(this.mockApi.history.patch[0].params).to.equal(params)
+    expect(this.mockApi.history.patch[0].params).to.deep.equal(params)
+  })
+
+  it('should allow the endpoint url to be overridden in config', async function() {
+    this.mockApi.onAny().reply(200, { data: jsonWidget1 })
+    const url = '/fish/1'
+
+    await jsonapiModule.actions.patch(stubContext, [normWidget1, { url: url }])
+    expect(this.mockApi.history.patch[0].url).to.equal(url)
   })
 
   it('should delete then add record(s) in the store (from server response)', async function() {

--- a/tests/unit/actions/post.spec.js
+++ b/tests/unit/actions/post.spec.js
@@ -38,7 +38,15 @@ describe('post', function() {
       { params: params },
     ])
 
-    expect(this.mockApi.history.post[0].params).to.equal(params)
+    expect(this.mockApi.history.post[0].params).to.deep.equal(params)
+  })
+
+  it('should allow the endpoint url to be overridden in config', async function() {
+    this.mockApi.onAny().reply(200, { data: jsonWidget1 })
+    const url = '/fish/1'
+
+    await jsonapiModule.actions.post(stubContext, [normWidget1, { url: url }])
+    expect(this.mockApi.history.post[0].url).to.equal(url)
   })
 
   it('should add record(s) to the store', async function() {


### PR DESCRIPTION
This PR changes how `axios` config options are handled.

Previously the `url` (aka `path`) was always generated by the module, then passed to the 'wrapper' methods (`get`, `post` etc) as the first argument,making overriding it difficult.

This PR uses the 'core' `axios` instance directly, and passes it config created by merging the user-supplied `config` onto the defaults. This means that all options to `axios` can be overridden on a per-request basis.

The main use-case for this is in #19, since now the `config` param can contain `url` which will be used instead of the path generated by the `getURL` method.

For example:
```
type = 'widget'
itemEndpoint = 'widget'
collectionEndpoint = 'widgets'
data = { _jv: { type: 'widget' } }

// Default (old) behaviour - will always treat type = itemEP = collectionEP
this.$store.dispatch('jv/get', data)

// New behaviour (simple)
this.$store.dispatch('jv/get', [data, { url: collectionEndpoint })

// New behaviour (from a function)

const myGetUrl = (data) => {
  if (data.hasOwnProperty('id')) {
    // single item
    return itemEndpoint
  }  else {
    // collection
    return collectionEndpoint
  }
}

this.$store.dispatch('jv/get', [{ _jv: { type: 'widget' } }, { url: myGetUrl(data) }])

```

Importantly, this also means no changes to the API of the module, and no need to implement complex mappings and rules for how to deal with type/ep differences.

As this is a nicer way to handle `axios` and config overrides generally, I'm likely to merge it anyway - but would appreciate feedback on whether this solves #19 adequately, and if it introduces any issues I haven't seen.