### PR TITLE
getURL uses links.self in model. Add/updates specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A module to access [JSONAPI](https://jsonapi.org) data from an API, using a Vuex
 - Uses [jsonpath](https://github.com/dchester/jsonpath) for filtering when getting objects from the store.
 - Records the status of actions (LOADING, SUCCESS, ERROR).
 - New data can overwrite, or be merged onto, existing records. (See [mergeRecords](#Configuration))
-- Override endpoint names per-request (for plural names etc). (See [Endpoints](#Endpoints))
+- Override endpoint names per-request (for plural names etc). Use `links.self` when available/applicable (See [Endpoints](#Endpoints))
 
 ## Setup
 
@@ -57,7 +57,7 @@ There are a number of features which are worth explaining in more detail. Many o
 
 - _Preserve JSON_ - The original JSONAPI record(s) can optionally be preserved in `_jv` if needed - for example if you need access to `meta` or other sections. To avoid duplication, the `data` section (`attributes`, `relationships` etc) is removed.
 
-- _Endpoints_ - by default this module assumes that object types and API endpoints (item and collection) all share the same name. however, some APIs use plurals or other variations on the endpoint names. You can override the endpoint name via the `axios` `url` config option (see [Endpoints](#endpoints))
+- _Endpoints_ - by default this module assumes that object types and API endpoints (item and collection) all share the same name. however, some APIs use plurals or other variations on the endpoint names. You can override the endpoint name via the `axios` `url` config option or the `links.self` attribute (see [Endpoints](#endpoints))
 
 ### Actions
 
@@ -379,6 +379,8 @@ For many of these options, more information is provided in the [Usage](#usage) s
 ## Endpoints
 
 By default `jsonapi-vuex` assumes that object type and API endpoint are the same. For example, `type: person` would have endpoint URLs of `/person` and `/person/1` for collections and single items.
+
+When performing request on an already known single item (like an update), `jsonapi-vuex` will use the `links.self` attribute of an item to determine the API endpoint, if it is present.
 
 However many APIs vary how endpoints are named - for example plurals (e.g. `type:person`, `/person/1` and `/people`), or cases where the endpoint doesn't match the type (e.g. `type: person` `/author` and `/author/1`) or even a combination (e.g. `type: person` `/author/1` and `/authors`)
 

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -543,11 +543,15 @@ const getTypeId = (data) => {
 const getURL = (data, post = false) => {
   let path = data
   if (typeof data === 'object') {
-    let { type, id } = data[jvtag]
-    path = type
-    // POST endpoints are always to collections, not items
-    if (id && !post) {
-      path += '/' + id
+    if ('links' in data[jvtag] && 'self' in data[jvtag]['links'] && !post) {
+      path = data[jvtag]['links']['self']
+    } else {
+      let { type, id } = data[jvtag]
+      path = type
+      // POST endpoints are always to collections, not items
+      if (id && !post) {
+        path += '/' + id
+      }
     }
   }
   if (!path.startsWith('/')) {
@@ -670,6 +674,7 @@ const _testing = {
   RecordError: RecordError,
   addJvHelpers: addJvHelpers,
   updateRecords: updateRecords,
+  getURL: getURL,
 }
 
 // Export this module

--- a/tests/unit/actions/delete.spec.js
+++ b/tests/unit/actions/delete.spec.js
@@ -24,7 +24,7 @@ describe('delete', function() {
     await jsonapiModule.actions.delete(stubContext, normWidget1)
 
     expect(this.mockApi.history.delete[0].url).to.equal(
-      `/${normWidget1['_jv']['type']}/${normWidget1['_jv']['id']}`
+      normWidget1['_jv']['links']['self']
     )
   })
 

--- a/tests/unit/actions/get.spec.js
+++ b/tests/unit/actions/get.spec.js
@@ -58,13 +58,14 @@ describe('get', function() {
     await jsonapiModule.actions.get(stubContext, normWidget1)
 
     expect(this.mockApi.history.get[0].url).to.equal(
-      `/${normWidget1['_jv']['type']}/${normWidget1['_jv']['id']}`
+      normWidget1['_jv']['links']['self']
     )
   })
 
   it('should make an api call to GET a collection', async function() {
     this.mockApi.onAny().reply(200, { data: jsonWidget1 })
     delete normWidget1['_jv']['id']
+    delete normWidget1['_jv']['links']
 
     await jsonapiModule.actions.get(stubContext, normWidget1)
 

--- a/tests/unit/fixtures/widget1.js
+++ b/tests/unit/fixtures/widget1.js
@@ -8,6 +8,9 @@ export function jsonFormat() {
       foo: 1,
       bar: 'baz',
     },
+    links: {
+      self: '/weirdPath/1',
+    },
     relationships: {
       widgets: {
         data: {
@@ -30,6 +33,9 @@ export function jsonFormatPatch() {
       foo: 'update',
       bar: 'baz',
     },
+    links: {
+      self: '/weirdPath/1',
+    },
     relationships: {
       widgets: {
         data: {
@@ -51,6 +57,9 @@ export function normFormat() {
     _jv: {
       type: 'widget',
       id: '1',
+      links: {
+        self: '/weirdPath/1',
+      },
       relationships: {
         widgets: {
           data: {
@@ -89,6 +98,9 @@ export function normFormatUpdate() {
     _jv: {
       type: 'widget',
       id: '1',
+      links: {
+        self: '/weirdPath/1',
+      },
       relationships: {
         widgets: {
           data: {

--- a/tests/unit/jsonapi-vuex.spec.js
+++ b/tests/unit/jsonapi-vuex.spec.js
@@ -454,6 +454,24 @@ describe('jsonapi-vuex tests', function() {
         expect(normWidget1['_jv'].isRel('no_such_rel')).to.be.false
       })
     })
+
+    describe('getURL function', function() {
+      it('returns the path if a path is provided', function() {
+        expect(_testing.getURL('a/path')).to.equal('/a/path')
+      })
+      describe('on objects', function() {
+        describe('without links.self', function() {
+          it('computes a path from type and id', function() {
+            expect(_testing.getURL(normWidget2)).to.equal('/widget/2')
+          })
+        })
+        describe('with links.self', function() {
+          it('uses the URL', function() {
+            expect(_testing.getURL(normWidget1)).to.equal('/weirdPath/1')
+          })
+        })
+      })
+    })
   }) // Helper methods
 
   describe('jsonapiModule getters', function() {


### PR DESCRIPTION
The JSONAPI specs includes a top level `self` link and this patch uses it whenever it's available on non-POST methods.

I'll add some docs if it has a chance to get merged :)