### PR TITLE
Add clearOnUpdate feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ There are a number of features which are worth explaining in more detail. Many o
 
 - _Follow relationships_ - If enabled then any `relationships` specified as `data` resources in the JSONAPI data will be expanded and stored alongside the attributes in the restructured data 'root'. Additionally, helper methods will be added to `_jv` to make dealing with these easier (see [Helper functions](#helper-functions))
 
+- _Clear on update_ - If enabled, then each new set of records is considered to be definitive for that `type`, and any other records of that `type` in the store will be removed. This option is useful for cases where you expect the API response to contain the full set of records from the server, as it avoids the need for manual cache expiry. The code will first apply the new records to the store, and then for each `type` which has had new records added, remove old ones. This is designed to be more efficient in terms of updating computed properties and UI redraws than emptying then repopulating the store.
+
 - _Included_ - If the JSONAPI record contains an `includes` section, the data in this will be added to the store alongisde the 'main' records. (If includes are not used, then you will need to use `getRelated` to fetch relationships).
 
 - _Merging_ - By default, data returned from the API overwrites records already in the store. However, this may lead to inconsistencies if using [Sparse fieldsets](https://jsonapi.org/format/#fetching-sparse-fieldsets) or otherwise obtaining only a subset of data from the API. If merging is enabled, then new data will be merged onto existing data. this does however mean that you are responsible for explicitly calling the `deleteRecord` mutation in cases where attributes ahve been removed in the API, as they will never be removed from the store, only added to.
@@ -375,6 +377,7 @@ For many of these options, more information is provided in the [Usage](#usage) s
 - `preserveJson` - Whether actions should return the API response json (minus `data`) in `_jv/json` (for access to `meta` etc) (defaults to `false`)
 - `actionStatusCleanAge` - What age must action status records be before they are removed (defaults to 600 seconds). Set to `0` to disable.
 - `mergeRecords`- Whether new records should be merged onto existing records in the store, or just replace them (defaults to `false`).
+- `clearOnUpdate` - Whether the store should clear old records and only keep new records when updating. Applies to the `type(s)` associated with the new records. (defaults to false).
 
 ## Endpoints
 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,10 @@ As `addRecords`, but explicitly replaces existing records.
 
 As `addRecords`, but explicitly merges onto existing records.
 
+#### clearRecords
+
+Will remove all records from the store (of a given type) which aren't contained in given response. (See [clearOnUpdate](#usage)).
+
 #### setStatus
 
 Sets the session status information in the store.

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -55,10 +55,11 @@ const mutations = () => {
       updateRecords(state, records, true)
     },
     clearRecords: (state, records) => {
-      for (let [type, item] of Object.entries(records)) {
+      const newRecords = normToStore(records)
+      for (let [type, item] of Object.entries(newRecords)) {
         if (type in state) {
-          const typeRecords = get(state, [type])
-          for (let id of Object.keys(typeRecords)) {
+          const storeRecords = get(state, [type])
+          for (let id of Object.keys(storeRecords)) {
             if (!item.hasOwnProperty(id)) {
               Vue.delete(state[type], id)
             }

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -54,6 +54,18 @@ const mutations = () => {
     mergeRecords: (state, records) => {
       updateRecords(state, records, true)
     },
+    clearRecords: (state, records) => {
+      for (let [type, item] of Object.entries(records)) {
+        if (type in state) {
+          const typeRecords = get(state, [type])
+          for (let id of Object.keys(typeRecords)) {
+            if (!item.hasOwnProperty(id)) {
+              Vue.delete(state[type], id)
+            }
+          }
+        }
+      }
+    },
     setStatus: (state, { id, status }) => {
       Vue.set(state[jvtag], id, { status: status, time: Date.now() })
     },
@@ -82,6 +94,9 @@ const actions = (api) => {
 
           let resData = jsonapiToNorm(results.data.data)
           context.commit('addRecords', resData)
+          if (jvConfig.clearOnUpdate) {
+            context.commit('clearRecords', resData)
+          }
           resData = checkAndFollowRelationships(context.state, resData)
           resData = preserveJSON(resData, results.data)
           context.commit('setStatus', {
@@ -381,15 +396,6 @@ const updateRecords = (state, records, merging = jvConfig.mergeRecords) => {
         }
       }
       Vue.set(state[type], id, data)
-    }
-    if (jvConfig.clearOnUpdate) {
-      // Ensure the store contains no records not in the response
-      const storeRecords = get(state, [type])
-      for (let id of Object.keys(storeRecords)) {
-        if (!item.hasOwnProperty(id)) {
-          Vue.delete(state[type], id)
-        }
-      }
     }
   }
 }

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -27,6 +27,8 @@ let jvConfig = {
   actionStatusCleanAge: 600,
   // Merge store records (or overwrite them)
   mergeRecords: false,
+  // Delete old records not contained in an update (on a per-type basis).
+  clearOnUpdate: false,
 }
 
 const jvtag = jvConfig['jvtag']
@@ -379,6 +381,15 @@ const updateRecords = (state, records, merging = jvConfig.mergeRecords) => {
         }
       }
       Vue.set(state[type], id, data)
+    }
+    if (jvConfig.clearOnUpdate) {
+      // Ensure the store contains no records not in the response
+      const storeRecords = get(state, [type])
+      for (let id of Object.keys(storeRecords)) {
+        if (!item.hasOwnProperty(id)) {
+          Vue.delete(state[type], id)
+        }
+      }
     }
   }
 }

--- a/tests/unit/actions/get.spec.js
+++ b/tests/unit/actions/get.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
 
+import { _testing } from '../../../src/jsonapi-vuex'
 import createStubContext from '../stubs/context'
 import createJsonapiModule from '../utils/createJsonapiModule'
 import {
@@ -207,6 +208,20 @@ describe('get', function() {
 
     // collections should have no top-level _jv
     expect(res).to.not.have.key('_jv')
+  })
+
+  it('should call clearRecords if clearOnUpdate is set', async function() {
+    this.mockApi.onAny().reply(200, { data: jsonWidget1 })
+
+    let { jvConfig } = _testing
+    jvConfig['clearOnUpdate'] = true
+
+    await jsonapiModule.actions.get(stubContext, normWidget1)
+
+    expect(stubContext.commit).to.have.been.calledWith(
+      'clearRecords',
+      normWidget1
+    )
   })
 
   it('should handle API errors', async function() {

--- a/tests/unit/jsonapi-vuex.spec.js
+++ b/tests/unit/jsonapi-vuex.spec.js
@@ -250,6 +250,23 @@ describe('jsonapi-vuex tests', function() {
         updateRecords(state, normRecord, true)
         expect(state).to.deep.equal(storeRecord)
       })
+      it('should not alter existing records in the store', function() {
+        const { updateRecords } = _testing
+        // Add a test record to the store
+        const state = { widget: { 4: { foo: 4 } } }
+        updateRecords(state, normRecord)
+        // test record should stil exist
+        expect(state['widget']).to.have.property('4')
+      })
+      it('should remove records from the store not in the response (clearOnUpdate)', function() {
+        const { updateRecords, jvConfig } = _testing
+        jvConfig['clearOnUpdate'] = true
+        // Add a test record to the store
+        const state = { widget: { 4: { foo: 4 } } }
+        updateRecords(state, normRecord)
+        // test record should no longer be present
+        expect(state).to.deep.equal(storeRecord)
+      })
     })
 
     describe('processIncludedRecords', function() {

--- a/tests/unit/jsonapi-vuex.spec.js
+++ b/tests/unit/jsonapi-vuex.spec.js
@@ -198,6 +198,16 @@ describe('jsonapi-vuex tests', function() {
       })
     })
 
+    describe('clearRecords', function() {
+      it('should remove records from the store not in the response (clearOnUpdate)', function() {
+        const { clearRecords } = jm.mutations
+        const state = { widget: { 4: { foo: 4 } } }
+        clearRecords(state, storeRecord)
+        // '4' not in storeRecord, so should no longer be present in state
+        expect(state['widget']).to.not.have.property('4')
+      })
+    })
+
     describe('setStatus', function() {
       it('should set the status for a specific id', function() {
         const state = { _jv: {} }
@@ -257,15 +267,6 @@ describe('jsonapi-vuex tests', function() {
         updateRecords(state, normRecord)
         // test record should stil exist
         expect(state['widget']).to.have.property('4')
-      })
-      it('should remove records from the store not in the response (clearOnUpdate)', function() {
-        const { updateRecords, jvConfig } = _testing
-        jvConfig['clearOnUpdate'] = true
-        // Add a test record to the store
-        const state = { widget: { 4: { foo: 4 } } }
-        updateRecords(state, normRecord)
-        // test record should no longer be present
-        expect(state).to.deep.equal(storeRecord)
       })
     })
 

--- a/tests/unit/jsonapi-vuex.spec.js
+++ b/tests/unit/jsonapi-vuex.spec.js
@@ -202,7 +202,7 @@ describe('jsonapi-vuex tests', function() {
       it('should remove records from the store not in the response (clearOnUpdate)', function() {
         const { clearRecords } = jm.mutations
         const state = { widget: { 4: { foo: 4 } } }
-        clearRecords(state, storeRecord)
+        clearRecords(state, normRecord)
         // '4' not in storeRecord, so should no longer be present in state
         expect(state['widget']).to.not.have.property('4')
       })


### PR DESCRIPTION
Provides for 2. in #55 

- Treat new data as 'definitive' (on a per-type basis).
- Remove old records from store during updateRecords()
