### PR TITLE
Add cleanPatch feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A module to access [JSONAPI](https://jsonapi.org) data from an API, using a Vuex
 - Records the status of actions (LOADING, SUCCESS, ERROR).
 - New data can overwrite, or be merged onto, existing records. (See [mergeRecords](#Configuration))
 - Override endpoint names per-request (for plural names etc). Use `links.self` when available/applicable (See [Endpoints](#Endpoints))
+- Patches can be 'cleaned' to ensure they only contain new or modified data. (See [cleanPatch](#Configuration))
 - Can query the API and receive restructured data, without modifying the store. (See the [Search action](#search))
 
 ## Setup
@@ -61,6 +62,8 @@ There are a number of features which are worth explaining in more detail. Many o
 - _Preserve JSON_ - The original JSONAPI record(s) can optionally be preserved in `_jv` if needed - for example if you need access to `meta` or other sections. To avoid duplication, the `data` section (`attributes`, `relationships` etc) is removed.
 
 - _Endpoints_ - by default this module assumes that object types and API endpoints (item and collection) all share the same name. however, some APIs use plurals or other variations on the endpoint names. You can override the endpoint name via the `axios` `url` config option or the `links.self` attribute (see [Endpoints](#endpoints))
+
+- _Clean Patches_ - by default, data passed to the `patch` action is used as-is. If `cleanPatch` is enabled, then the patch object is compared to the record in the store (if it exists), and any attributes with identical values are removed. This means that the final `patch` will only contain new or modified attributes, which is safer and more efficient, as it avoids sending unnecessary or 'stale' data.
 
 ### Actions
 
@@ -399,6 +402,7 @@ For many of these options, more information is provided in the [Usage](#usage) s
 - `actionStatusCleanAge` - What age must action status records be before they are removed (defaults to 600 seconds). Set to `0` to disable.
 - `mergeRecords`- Whether new records should be merged onto existing records in the store, or just replace them (defaults to `false`).
 - `clearOnUpdate` - Whether the store should clear old records and only keep new records when updating. Applies to the `type(s)` associated with the new records. (defaults to false).
+- `cleanPatch` - If enabled, patch object is compared to the record in the store, and only unique or modified attributes are kept in the patch. (defaults to false).
 
 ## Endpoints
 

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "jsonpath": "^1.0.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.get": "^4.4.2",
+    "lodash.isequal": "^4.5.0",
     "lodash.merge": "^4.6.1"
   },
   "peerDependencies": {

--- a/tests/unit/jsonapi-vuex.spec.js
+++ b/tests/unit/jsonapi-vuex.spec.js
@@ -241,6 +241,39 @@ describe('jsonapi-vuex tests', function() {
   }) // mutations
 
   describe('jsonapiModule helpers', function() {
+    describe('cleanPatch', function() {
+      it('should return patch unmodified if record not in state', function() {
+        const { jvConfig, cleanPatch } = _testing
+        jvConfig.cleanPatch = true
+
+        const res = cleanPatch(normWidget1Patch, {})
+        expect(res).to.deep.equal(normWidget1Patch)
+      })
+      it('should pick modified/new attributes from a record (no _jv)', function() {
+        const { jvConfig, cleanPatch } = _testing
+        jvConfig.cleanPatch = true
+
+        const res = cleanPatch(normWidget1Patch, normRecord)
+        expect(res).to.not.have.property('bar')
+        expect(res['foo']).to.equal('update')
+      })
+      it('should pick modified/new attributes from a record (with _jv)', function() {
+        const { addJvHelpers, jvConfig, cleanPatch } = _testing
+        jvConfig.cleanPatch = true
+
+        const patch = JSON.parse(JSON.stringify(normWidget1))
+        patch['foo'] = 'update'
+        // Add the relationship to root (tests attrs getter)
+        patch['widgets'] = {}
+        addJvHelpers(patch)
+
+        const res = cleanPatch(patch, normRecord)
+        expect(res).to.not.have.property('bar')
+        expect(res['foo']).to.equal('update')
+        expect(res).to.not.have.property('widgets')
+      })
+    })
+
     describe('updateRecords', function() {
       it('should add several records to the store (replace)', function() {
         const { updateRecords } = _testing

--- a/tests/unit/utils/createJsonapiModule.js
+++ b/tests/unit/utils/createJsonapiModule.js
@@ -10,6 +10,7 @@ export default function(api, options = {}) {
     followRelationshipsData: false,
     preserveJson: false,
     mergeRecords: false,
+    patchClean: false,
     ...options,
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6409,6 +6409,11 @@ lodash.isarray@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
   integrity sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
 lodash.isplainobject@^4.0.0:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"


### PR DESCRIPTION
- If enabled, patches will only contain new and modified attributes
- Compares to existing record in store (or uses patch as-is if none found)

Fixes 1st part of #62 