### PR TITLE
Don't try to add a '/' axios handles this for us.

### DIFF
--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -603,9 +603,6 @@ const getURL = (data, post = false) => {
       }
     }
   }
-  if (!path.startsWith('/')) {
-    path = '/' + path
-  }
   return path
 }
 

--- a/tests/unit/actions/get.spec.js
+++ b/tests/unit/actions/get.spec.js
@@ -71,7 +71,7 @@ describe('get', function() {
     await jsonapiModule.actions.get(stubContext, normWidget1)
 
     expect(this.mockApi.history.get[0].url).to.equal(
-      `/${normWidget1['_jv']['type']}`
+      `${normWidget1['_jv']['type']}`
     )
   })
 

--- a/tests/unit/actions/patch.spec.js
+++ b/tests/unit/actions/patch.spec.js
@@ -39,7 +39,7 @@ describe('patch', function() {
     await jsonapiModule.actions.patch(stubContext, normWidget1Patch)
 
     expect(this.mockApi.history.patch[0].url).to.equal(
-      `/${normWidget1Patch['_jv']['type']}/${normWidget1Patch['_jv']['id']}`
+      `${normWidget1Patch['_jv']['type']}/${normWidget1Patch['_jv']['id']}`
     )
   })
 

--- a/tests/unit/actions/post.spec.js
+++ b/tests/unit/actions/post.spec.js
@@ -25,7 +25,7 @@ describe('post', function() {
     await jsonapiModule.actions.post(stubContext, normWidget1)
 
     expect(this.mockApi.history.post[0].url).to.equal(
-      `/${normWidget1['_jv']['type']}`
+      `${normWidget1['_jv']['type']}`
     )
   })
 

--- a/tests/unit/actions/search.spec.js
+++ b/tests/unit/actions/search.spec.js
@@ -54,7 +54,7 @@ describe('search', function() {
     await jsonapiModule.actions.search(stubContext, normWidget1)
 
     expect(this.mockApi.history.get[0].url).to.equal(
-      `/${normWidget1['_jv']['type']}`
+      `${normWidget1['_jv']['type']}`
     )
   })
 

--- a/tests/unit/jsonapi-vuex.spec.js
+++ b/tests/unit/jsonapi-vuex.spec.js
@@ -509,12 +509,12 @@ describe('jsonapi-vuex tests', function() {
 
     describe('getURL function', function() {
       it('returns the path if a path is provided', function() {
-        expect(_testing.getURL('a/path')).to.equal('/a/path')
+        expect(_testing.getURL('a/path')).to.equal('a/path')
       })
       describe('on objects', function() {
         describe('without links.self', function() {
           it('computes a path from type and id', function() {
-            expect(_testing.getURL(normWidget2)).to.equal('/widget/2')
+            expect(_testing.getURL(normWidget2)).to.equal('widget/2')
           })
         })
         describe('with links.self', function() {


### PR DESCRIPTION
Axios is 'clever' enough to tell the difference between `url` in config being a full or relative URL. If it is relative, and it appends it to `baseURL` then it will add a `/` if necessary. This means that we don't need to do this manually (and potentially get it wrong if the supplied value in `url` is full.

Quick testing here: https://codepen.io/mrichar1/pen/mYYQqQ