### PR TITLE
getRelated: relationship 'filtering'

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,15 @@ const widgetSearch = (text) => {
 
 _Note_ - in many cases you may prefer to use the jsonapi server-side `include` option to get data on relationships included in your original query. (See [Related Items](#related-items)).
 
-Like the RESTful actions, this takes 2 arguments - the URL/object to be acted on, and an axios config object. It returns a deeply nested restructured tree - `relationship -> type -> id -> data`.
+Like the RESTful actions, this takes 2 arguments - the string or object to be acted on, and an axios config object. It returns a deeply nested restructured tree - `relationship -> type -> id -> data`.
 
 _Note_ - [getRelated](#getrelated) only works on specific items, not collections.
+
+By default this action will fetch the record specified from the API, then work out it's relationships and also fetch those.
+
+If the argument is a string, it can optionally take a 3rd argument, e.g. `type/id/relationship` to cause only the named relationship to be followed.
+
+If the argument is an object, then if the object contains a `_jv/relationships` section, then only these relationships will are followed. If the relationships section contains keys (i.e relationship `names`) but no values (i.e. [resource linkage](https://jsonapi.org/format/#fetching-relationships)) then these will be fetched from the API.
 
 ```js
 // Assuming the API holds the following data
@@ -169,6 +175,38 @@ this.$store.dispatch('jv/getRelated', 'widget/1').then((data) => {
 
 // Get only the items in the 'widgets' relationship
 this.$store.dispatch('jv/getRelated', 'widget/1/widgets').then((data) => {
+  console.log(data)
+})
+
+// Equivalent, using object instead of string argument
+const customRels = {
+  _jv: {
+    type: 'widget',
+    id: '1',
+    relationships: {
+      widgets: {
+        data: {
+          type: 'widget',
+          id: '2',
+        },
+      },
+    },
+  },
+}
+
+// Equivalent, but 'doohickeys' resource linkage will be fetched from the server
+// i.e. { data: { type: 'doohickey', id: '10' }}
+const customRelsNoData = {
+  _jv: {
+    type: 'widget',
+    id: '1',
+    relationships: {
+      doohickeys: undefined,
+    },
+  },
+}
+
+this.$store.dispatch('jv/getRelated', customRels).then((data) => {
   console.log(data)
 })
 ```

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-vue": "^5.2.2",
     "fake-json-api-server": "^1.6.0",
-    "geckodriver": "^1.14.1",
+    "geckodriver": "^1.16.2",
     "husky": "^1.3.1",
     "karma": "^3.0.0",
     "karma-chai": "^0.1.0",

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -116,7 +116,7 @@ const actions = (api) => {
       action[jvtag + 'Id'] = actionId
       return action
     },
-    getRelated: (context, args) => {
+    getRelated: async (context, args) => {
       const data = unpackArgs(args)[0]
       let [, id, relName] = getTypeId(data)
       if (!id) {
@@ -124,59 +124,56 @@ const actions = (api) => {
       }
       const actionId = actionSequence(context)
       context.commit('setStatus', { id: actionId, status: STATUS_LOAD })
+
+      let rels
+      try {
+        let record = await context.dispatch('get', args)
+
+        rels = get(record, [jvtag, 'relationships'], {})
+        if (relName && rels) {
+          // Only process requested relname
+          rels = { [relName]: rels[relName] }
+        }
+      } catch (error) {
+        // Log and re-throw if 'get' action fails
+        context.commit('setStatus', { id: actionId, status: STATUS_ERROR })
+        throw error
+      }
+
       // We can't pass multiple/non-promise vars in a promise chain,
       // so must define such vars in a higher scope
-
       let relNames = []
-      //Get initial record
-      let action = context
-        .dispatch('get', args)
-        .then((record) => {
-          let rels = get(record, [jvtag, 'relationships'], {})
-          if (relName && rels) {
-            // Only process requested relname
-            rels = { [relName]: rels[relName] }
+      let relPromises = []
+
+      // Iterate over all records in rels
+      for (let [relName, relItems] of Object.entries(rels)) {
+        let relData
+        // Extract relationships from 'data' (type/id)
+        if ('data' in relItems) {
+          relData = relItems['data']
+          if (!Array.isArray(relData)) {
+            // Treat as if always an array
+            relData = [relData]
           }
-          return rels
-        })
-        .catch((error) => {
-          // Log and re-throw if 'get' action fails
-          context.commit('setStatus', { id: actionId, status: STATUS_ERROR })
-          throw error
-        })
-        .then((rels) => {
-          // Store an array of relNames & promises
-          // let relNames = []
-          let relPromises = []
-          // Iterate over all records in rels
-          for (let [relName, relItems] of Object.entries(rels)) {
-            let relData
-            // Extract relationships from 'data' (type/id)
-            if ('data' in relItems) {
-              relData = relItems['data']
-              if (!Array.isArray(relData)) {
-                // Treat as if always an array
-                relData = [relData]
-              }
-            } else if ('links' in relItems) {
-              relData = relItems['links']['related']
-              if (!(typeof relData === 'string')) {
-                relData = relData['href']
-              }
-              relData = [relData]
-            }
-            for (let entry of relData) {
-              // Rewrite 'data' objects to normalised form
-              if (!(typeof entry === 'string')) {
-                entry = { [jvtag]: entry }
-              }
-              relNames.push(relName)
-              relPromises.push(context.dispatch('get', entry))
-            }
+          // Or from 'links/related'
+        } else if ('links' in relItems) {
+          relData = relItems['links']['related']
+          if (!(typeof relData === 'string')) {
+            relData = relData['href']
           }
-          // 'Merge' all promise resolution/rejection
-          return Promise.all(relPromises)
-        })
+          relData = [relData]
+        }
+        for (let entry of relData) {
+          // Rewrite 'data' objects to normalised form
+          if (!(typeof entry === 'string')) {
+            entry = { [jvtag]: entry }
+          }
+          relNames.push(relName)
+          relPromises.push(context.dispatch('get', entry))
+        }
+      }
+      // 'Merge' all promise resolution/rejection
+      let action = Promise.all(relPromises)
         .then((results) => {
           let related = {}
           results.forEach((result, i) => {

--- a/tests/unit/actions/getRelated.spec.js
+++ b/tests/unit/actions/getRelated.spec.js
@@ -51,12 +51,15 @@ describe('getRelated', function() {
     stubContext = createStubContext(jsonapiModule)
   })
 
-  it('Should throw an error if passed an object with no id', function() {
+  it('Should throw an error if passed an object with no id', async function() {
     delete normWidget1['_jv']['id']
     // Wrap method in an empty method to catch transpiled throw (https://www.chaijs.com/api/bdd/#methodThrow)
-    expect(() =>
-      jsonapiModule.actions.getRelated(stubContext, normWidget1)
-    ).to.throw('No id specified')
+    try {
+      await jsonapiModule.actions.getRelated(stubContext, normWidget1)
+      throw 'Should have thrown an error (no id)'
+    } catch (error) {
+      expect(error).to.equal('No id specified')
+    }
   })
 
   it("should get a record's single related item (using 'data')", async function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4627,16 +4627,16 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-geckodriver@^1.14.1:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/geckodriver/-/geckodriver-1.16.0.tgz#ec97f3b175522ce31584af7b42b4ff978e2be170"
-  integrity sha512-im4iInm9n3ntXlsmaoQx5wP1jMP40t+FQBbvlEr5jMCq3ruKcN60/kXn7eYNn0bchpgQf6nXVBy4p8SEaMpI4w==
+geckodriver@^1.16.2:
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/geckodriver/-/geckodriver-1.16.2.tgz#4766e6eb6835e9ec8797f1dce1966df2b3fb5985"
+  integrity sha512-kXZP4QferAv57Ru4Fx2WYuu//ErKJP4hPEkJm4mSETo42jsdYFwdNxwQ4vCGhf14gsCdxU9YrwNupJ8gr1GxPg==
   dependencies:
     adm-zip "0.4.11"
     bluebird "3.4.6"
     got "5.6.0"
     https-proxy-agent "2.2.1"
-    tar "4.0.2"
+    tar "4.4.2"
 
 get-caller-file@^1.0.1:
   version "1.0.3"
@@ -6828,7 +6828,7 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
-minipass@^2.2.1, minipass@^2.3.4:
+minipass@^2.2.1, minipass@^2.2.4, minipass@^2.3.4:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
   integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
@@ -6836,7 +6836,7 @@ minipass@^2.2.1, minipass@^2.3.4:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
-minizlib@^1.0.4, minizlib@^1.1.1:
+minizlib@^1.1.0, minizlib@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
   integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
@@ -9730,15 +9730,17 @@ tapable@^1.0.0, tapable@^1.1.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.1.tgz#4d297923c5a72a42360de2ab52dadfaaec00018e"
   integrity sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA==
 
-tar@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.0.2.tgz#e8e22bf3eec330e5c616d415a698395e294e8fad"
-  integrity sha512-4lWN4uAEWzw8aHyBUx9HWXvH3vIFEhOyvN22HfBzWpE07HaTBXM8ttSeCQpswRo5On4q3nmmYmk7Tomn0uhUaw==
+tar@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.2.tgz#60685211ba46b38847b1ae7ee1a24d744a2cd462"
+  integrity sha512-BfkE9CciGGgDsATqkikUHrQrraBCO+ke/1f6SFAEMnxyyfN9lxC+nW1NFWMpqH865DhHIy9vQi682gk1X7friw==
   dependencies:
     chownr "^1.0.1"
-    minipass "^2.2.1"
-    minizlib "^1.0.4"
+    fs-minipass "^1.2.5"
+    minipass "^2.2.4"
+    minizlib "^1.1.0"
     mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
 tar@^4:


### PR DESCRIPTION
Alternative approach to fix the issues highlighted in #66 with `getRelated` filtering on relationships.

This PR adds new treatment of objects as the argument to `getRelated`.

As before, a 'simple' object causes that record to be fetched from the API, and it's relationships then processed.

If the object contains 'full' `_jv/relationships`, then this object is used instead of doing an API get.

If `_jv/relationships` only contains relationship names (i.e keys, but value === `undefined`), then the resource linkage is fetched from the API (`/type/id/relationships/relationshipName`) and used.

This allows a wider variety of ways to request none, some or all relationships be processed. It also makes `getRelated` more efficient if the record is already in the `store` as it prevents it being 're-fetched'.