### PR TITLE
Allow limiting of recursion in relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ let item1 = this.$store.getters['jv/get']('widget/1')
 
 ```
 
-_Note_ - since relationships can be recursive, calling methods on such objects which try to walk the entire tree will cause recursion errors (e.g. `JSON.stringify`). In order to prevent this common error, a `toJSON` function is added to spot and remove any potentially recursive relationships. In these cases the getter is relpaced with just the `_jv` section, containing `type` and `id` as an indicator of the unfollowed relationship. This behaviour can be disabled - see [toJSON](#Configuration).
+_Note_ - since relationships can be recursive, calling methods on such objects which try to walk the entire tree will cause recursion errors (e.g. `JSON.stringify`). In order to prevent this common error, recursive relationships are replaced with just the `_jv` section, containing `type` and `id` as an indicator of the unfollowed relationship. Recursive relationships can be enabled with the configuration option [recurseRelationships](#Configuration).
 
 ## Helper Functions
 
@@ -487,7 +487,7 @@ For many of these options, more information is provided in the [Usage](#usage) s
 - `clearOnUpdate` - Whether the store should clear old records and only keep new records when updating. Applies to the `type(s)` associated with the new records. (defaults to false).
 - `cleanPatch` - If enabled, patch object is compared to the record in the store, and only unique or modified attributes are kept in the patch. (defaults to false).
 - `cleanPatchProps` - If cleanPatch is enabled, an array of `_jv` properties that should be preserved - `links`, `meta`, and/or `relationships`. (defaults to `[]`).
-- `toJSON` - Add a `toJSON` function to records to remove potentially recursive relationships when serialising to JSON. (defaults to true).
+- `recurseRelationships` - If `false`, replaces recursive relationships with a normalised resource identifier (i.e `{ _jv: { type: 'x', id: 'y' } }`). (defaults to `false`).
 
 ## Endpoints
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",
-    "lodash.merge": "^4.6.2"
+    "lodash.merge": "^4.6.2",
+    "lodash.set": "^4.3.2"
   },
   "peerDependencies": {
     "vue": "^2.5.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5854,9 +5854,9 @@ is-resolvable@^1.0.0:
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
 is-retry-allowed@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
-  integrity sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
+  integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
 
 is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
@@ -6615,6 +6615,11 @@ lodash.rest@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.rest/-/lodash.rest-4.0.5.tgz#954ef75049262038c96d1fc98b28fdaf9f0772aa"
   integrity sha1-lU73UEkmIDjJbR/Jiyj9r58Hcqo=
 
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
+
 lodash.transform@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.transform/-/lodash.transform-4.6.0.tgz#12306422f63324aed8483d3f38332b5f670547a0"
@@ -6967,7 +6972,15 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
-minipass@^2.2.1, minipass@^2.2.4, minipass@^2.3.5:
+minipass@^2.2.1, minipass@^2.2.4:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.5.1.tgz#cf435a9bf9408796ca3a3525a8b851464279c9b8"
+  integrity sha512-dmpSnLJtNQioZFI5HfQ55Ad0DzzsMAb+HfokwRTNXwEQjepbTkl5mtIlSVxGIkOkxlpX7wIn5ET/oAd9fZ/Y/Q==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
+minipass@^2.3.5:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
   integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==


### PR DESCRIPTION
* Track seen rels via seenState object
* Pass object as arg to get (called by rel getters)
* recurseRelationships config option (defaults false)
* toJSON removed as redundant to this option
* Updates tests.
* Fixes #83