### PR TITLE
Misc fixes for relationship recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ _Note_ - Since the `dispatch` method can only accept a single argument, if both 
 
 The first argument is an object containing [restructured data](#restructured-data). Actions which take no `data` argument apart from the record (`get` and `delete`) can also accept a URL to fetch (relative to `axios` `baseURL` (if set) leading slash is optional). This means you don't need to create an 'empty' restructured data object to get or delete a record.
 
-_Note_ - The `get` action differs that it returns the results of the action, rather than querying the store for the requested item/collection. This is because the `get` may be a partial or filtered request, returning only a subset of the item/collection. This means that if you use these results, later updates to the stores will not be reflected. If you want to query the store, then use the `get` getter once the action has returned.
+_Note_ - The `get` action differs in that it returns the results of the action, rather than querying the store for the requested item/collection. This is because the `get` may be a partial or filtered request, returning only a subset of the item/collection. This means that if you use these results, later updates to the stores will not be reflected. If you want to query the store, then use the `get` getter once the action has returned.
 
 Some examples:
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,11 @@ These actions take 2 arguments: the path/object to be acted on, and an (optional
 
 _Note_ - Since the `dispatch` method can only accept a single argument, if both arguments are used, the argument must be an array.
 
-The first argument is an object containing [restructured data](#restructured-data). Actions which take no `data` argument apart from the record (`get` and `delete`) can also accept a URL to fetch (relative to `axios` `baseURL` (if set) leading slash is optional). This means you don't need to create an 'empty' restructured data object to get or delete a record. Some examples:
+The first argument is an object containing [restructured data](#restructured-data). Actions which take no `data` argument apart from the record (`get` and `delete`) can also accept a URL to fetch (relative to `axios` `baseURL` (if set) leading slash is optional). This means you don't need to create an 'empty' restructured data object to get or delete a record.
+
+_Note_ - The `get` action differs that it returns the results of the action, rather than querying the store for the requested item/collection. This is because the `get` may be a partial or filtered request, returning only a subset of the item/collection. This means that if you use these results, later updates to the stores will not be reflected. If you want to query the store, then use the `get` getter once the action has returned.
+
+Some examples:
 
 ```js
 // To get all items in a collection, using a string path:
@@ -349,6 +353,10 @@ There are 2 getters available. `get` and `status`.
 #### get
 
 Get returns information directly from the store for previously cached records. This is useful for performance reasons, or for use in computed properties.
+
+Get returns an object with getters that point to the data in the store. This means that updates to the store will be dynamically reflected in the results object. However it also means that it is not possible to modify this object as getters aren't writeable.
+
+If you wish to modify the results object (e.g. for patching) then you should use the [`utils.deepCopy`](#utility-functions) method on the object to make a copy that is safe to modify. This deep copies the object, while preserving the [Helper Functions](#helper-functions).
 
 ```js
 computed: {
@@ -515,6 +523,14 @@ Adds the 'helper' functions/properties to `_jv` in a restructured object.
 If you wish to clean patches on a per-patch basis, then set the `cleanPatch` configuration option to false, and instead use this method on your patch record prior to passing it to the action.
 
 `cleanPatch` takes 3 arguments - the patch data, the state to be compared to, and an array of `_jv` properties to be preserved (see `cleanPatchProps` config option).
+
+### `deepCopy`
+
+Makes a deep copy of a normalised object, and adds/updates the [Helper functions](#helper-functions). This is done because walking the object will normally cause the helper functions to be called, resulting in static (and out-of-date) results.
+
+This function is designed for situations where you wish to modify the results of a `getter` call, which will throw an error if any of it's data is modified.
+
+_Note_ - Be aware that this copy will be a 'static' version of the original object - if the store is subsequently updated, the copied object will no longer reflect this.
 
 ### `getTypeId`
 

--- a/examples/testapp.json
+++ b/examples/testapp.json
@@ -12,7 +12,7 @@
           "widgets": {
             "data": {
               "type": "widget",
-              "id": "3"
+              "id": "2"
             }
           }
         }
@@ -45,6 +45,14 @@
         "attributes": {
           "name": "spring",
           "color": "silver"
+        },
+        "relationships": {
+          "widgets": {
+            "data": {
+              "type": "widget",
+              "id": "1"
+            }
+          }
         }
       }
     ]

--- a/examples/testapp/src/components/JsonapiVuex.vue
+++ b/examples/testapp/src/components/JsonapiVuex.vue
@@ -89,6 +89,8 @@
 </template>
 
 <script>
+import { utils } from '../../../../src/jsonapi-vuex'
+
 export default {
   name: 'JsonapiVuex',
   data: () => {
@@ -110,12 +112,12 @@ export default {
       return this.$store.getters['jv/get']('widget')
     },
     widget1() {
-      return this.$store.getters['jv/get']('widget/1')
+      return utils.deepCopy(this.$store.getters['jv/get']('widget/1'))
     },
   },
   created() {
     this.$store.dispatch('jv/get', 'widget')
-    this.$store.dispatch('jv/search', 'widget').then((res) => {
+    this.$store.dispatch('jv/get', 'widget').then((res) => {
       this.searchResult = res
     })
   },

--- a/examples/testapp/src/store.js
+++ b/examples/testapp/src/store.js
@@ -17,6 +17,6 @@ const api = axios.create({
 export default new Vuex.Store({
   strict: true,
   modules: {
-    jv: jsonapiModule(api, { action_status_clean_age: 10 }),
+    jv: jsonapiModule(api, {}),
   },
 })

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -1,6 +1,5 @@
 import Vue from 'vue'
 import get from 'lodash.get'
-import set from 'lodash.set'
 import isEqual from 'lodash.isequal'
 import merge from 'lodash.merge'
 import cloneDeep from 'lodash.clonedeep'
@@ -359,7 +358,7 @@ const actions = (api) => {
 
 const getters = () => {
   return {
-    get: (state, getters) => (data, jsonpath, seenState) => {
+    get: (state, getters) => (data, jsonpath, seen) => {
       let result
       if (!data) {
         // No data arg - return whole state object
@@ -380,12 +379,7 @@ const getters = () => {
             // whole collection, indexed by id
             result = state[type]
           }
-          result = checkAndFollowRelationships(
-            state,
-            getters,
-            result,
-            seenState
-          )
+          result = checkAndFollowRelationships(state, getters, result, seen)
         } else {
           // no records for that type in state
           return {}
@@ -435,10 +429,18 @@ const jsonapiModule = (api, conf = {}) => {
 
 // Helper methods
 
+const deepCopy = (obj) => {
+  // Deep copy a normalised object, then re-add helper nethods
+  const copyObj = cloneDeep(obj)
+  if (Object.entries(copyObj).length) {
+    return addJvHelpers(copyObj)
+  }
+  return obj
+}
+
 const cleanPatch = (patch, state = {}, jvProps = []) => {
   // Add helper properties (use a copy to prevent side-effects)
-  const modPatch = cloneDeep(patch)
-  addJvHelpers(modPatch)
+  let modPatch = deepCopy(patch)
   const attrs = get(modPatch, [jvtag, 'attrs'])
   let clean = { [jvtag]: {} }
   // Only try to clean the patch if it exists in the store
@@ -484,10 +486,6 @@ const updateRecords = (state, records, merging = jvConfig.mergeRecords) => {
 }
 
 const addJvHelpers = (obj) => {
-  // Do nothing if already has helpers
-  if (get(obj[jvtag]['isRel'])) {
-    return obj
-  }
   // Add Utility functions to _jv child object
   Object.assign(obj[jvtag], {
     isRel(name) {
@@ -509,6 +507,8 @@ const addJvHelpers = (obj) => {
       }
       return rel
     },
+    // Allow to be redefined
+    configurable: true,
   })
   Object.defineProperty(obj[jvtag], 'attrs', {
     get() {
@@ -520,6 +520,8 @@ const addJvHelpers = (obj) => {
       }
       return att
     },
+    // Allow to be redefined
+    configurable: true,
   })
   return obj
 }
@@ -551,16 +553,16 @@ const preserveJSON = (data, json) => {
   return data
 }
 
-const checkAndFollowRelationships = (state, getters, records, seenState) => {
+const checkAndFollowRelationships = (state, getters, records, seen) => {
   if (jvConfig.followRelationshipsData) {
     let resData = {}
     if (jvtag in records) {
       // single item
-      resData = followRelationships(state, getters, records, seenState)
+      resData = followRelationships(state, getters, records, seen)
     } else {
       // multiple items
       for (let [key, item] of Object.entries(records)) {
-        resData[key] = followRelationships(state, getters, item, seenState)
+        resData[key] = followRelationships(state, getters, item, seen)
       }
     }
     if (resData) {
@@ -571,49 +573,64 @@ const checkAndFollowRelationships = (state, getters, records, seenState) => {
 }
 
 // Follow relationships and expand them into _jv/rels
-const followRelationships = (state, getters, record, seenState = {}) => {
-  // Copy item before modifying
-  const data = cloneDeep(record)
+const followRelationships = (state, getters, record, seen = []) => {
+  // Make a shallow copy of the object's keys (by reference - preserve getters).
+  // We can't add rels to the original object, otherwise Vue's watchers
+  // spot the potential recursion and throw an error
+  let data = {}
+  // Use entries() as we need to iterate the values to get the 'real' record
+  for (let [key] of Object.entries(record)) {
+    data[key] = record[key]
+  }
 
+  let [type, id] = getTypeId(data)
   const relNames = get(data, [jvtag, 'relationships'], {})
   for (let [relName, relInfo] of Object.entries(relNames)) {
     let isItem = false
+    if (!seen.length) {
+      // we're at the 'start' so add the 'root' object info
+      seen = [[relName, type, id]]
+    }
     // We can only work with data, not links since we need type & id
     if ('data' in relInfo && relInfo.data) {
       let relData = relInfo['data']
-      data[relName] = {}
       if (!Array.isArray(relData)) {
         // Convert to an array to keep things DRY
         isItem = true
         relData = [relData]
+      } else {
+        // Collections of rels are nested under the relName
+        if (!hasProperty(data, relName)) {
+          data[relName] = {}
+        }
       }
       for (let relItem of relData) {
-        let [type, id] = getTypeId({ [jvtag]: relItem })
+        let [relType, relId] = getTypeId({ [jvtag]: relItem })
         let rootObj = data[relName]
-        let key = id
+        let key = relId
         if (isItem) {
           // Store directly under relName, not under an id
           rootObj = data
           key = relName
         }
-        if (type && id) {
+
+        if (!hasProperty(rootObj, key)) {
           Object.defineProperty(rootObj, key, {
             get() {
-              // Return a getter for objects not yet seen...
-              let path = [relName]
-              // Prefix key & id with _ as _.set treats ints are indices, not keys
-              if (relName !== key) {
-                path.push(`_${key}`)
-              }
-              path.push(type, `_${id}`)
-              if (!get(seenState, path)) {
-                if (!jvConfig.recurseRelationships && type && id) {
-                  set(seenState, path, true)
-                }
-                return getters.get(`${type}/${id}`, undefined, seenState)
+              let current = [relName, relType, relId]
+              // Stop if seen contains an array which matches 'current'
+              if (
+                !jvConfig.recurseRelationships &&
+                seen.some((a) => a.every((v, i) => v === current[i]))
+              ) {
+                return { [jvtag]: { type: relType, id: relId } }
               } else {
-                // ... otherwise return a resource identifier object
-                return { [jvtag]: { type: type, id: id } }
+                // prettier-ignore
+                return getters.get(
+                  `${relType}/${relId}`,
+                  undefined,
+                  [...seen, [relName, relType, relId]]
+                )
               }
             },
             enumerable: true,
@@ -771,6 +788,7 @@ const processIncludedRecords = (context, results) => {
 const utils = {
   addJvHelpers: addJvHelpers,
   cleanPatch: cleanPatch,
+  deepCopy: deepCopy,
   getTypeId: getTypeId,
   getURL: getURL,
   jsonapiToNorm: jsonapiToNorm,
@@ -782,6 +800,7 @@ const utils = {
 const _testing = {
   actionSequence: actionSequence,
   getTypeId: getTypeId,
+  deepCopy: deepCopy,
   jsonapiToNorm: jsonapiToNorm,
   jsonapiToNormItem: jsonapiToNormItem,
   normToJsonapi: normToJsonapi,

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -576,7 +576,7 @@ const checkAndFollowRelationships = (state, getters, records, seen) => {
 const followRelationships = (state, getters, record, seen = []) => {
   // Make a shallow copy of the object's keys (by reference - preserve getters).
   // We can't add rels to the original object, otherwise Vue's watchers
-  // spot the potential recursion and throw an error
+  // spot the potential loop and throw an error
   let data = {}
   // Use entries() as we need to iterate the values to get the 'real' record
   for (let [key] of Object.entries(record)) {

--- a/tests/e2e/specs/test.js
+++ b/tests/e2e/specs/test.js
@@ -24,8 +24,8 @@ module.exports = {
 
     // Expanded related objects
     be.element('#rel_span_relname').text.to.equal('widgets')
-    be.element('#rel_span_name').text.to.equal('spring')
-    be.element('#rel_span_color').text.to.equal('silver')
+    be.element('#rel_span_name').text.to.equal('gear')
+    be.element('#rel_span_color').text.to.equal('blue')
 
     // Values from initial API search in table
     be.element('#search_name_1').text.to.equal('sprocket')


### PR DESCRIPTION
- Stop making copies everywhere - preserve the getters/setters in `get` results.
- Simplify relationship recursion handling
- Create `deepCopy` (utils) method to preserve helpers when copying/modifying such objects.
- Make helper methods configurable to allow updating them.
- Use `deepCopy` in cleanPatch
- Update docs & tests

Aims to fix the issues raised in #83 after `2.2.0` release.