### PR TITLE
getRelated getter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,21 @@
 language: node_js
-
 node_js:
 - node
-
 env:
   global:
-    - DISPLAY=:99.0
-
+  - DISPLAY=:99.0
 services:
-  - xvfb
-
-# Install the latest firefox for nightwatch e2e tests
+- xvfb
 addons:
   firefox: latest
-
 script:
-  - npm run lint
-  - npm test
-
+- npm run lint
+- npm test
 deploy:
   provider: npm
   email: m.richardson@ed.ac.uk
   api_key:
-    secure: X+3Mq/DhHS+KxW78iR+BhOS3hcv8HHj700Q8EKA2xTs3URxezm4M2Jw6Z+bCkvOImvq0xecaCsnLxyKVPAdr71brHh01P/7UO0lcEnXInMHnGMp4b1Mp24Z25x/2j3PRvGCO2WwUnRh7DO5v+k9N+hUo+56xlCHwf3TC4yg2zKZpHHnas3ed0TcbvrCp/qcmj06yuT0q/y1D7yH2xKYDJG+PLsP/SPlLdfmwwDLKx/dfB7MQ+JmuMq9/eIPfBUrag3CfenjO5+7p7Bv28wGj1ft+FbZuOO5YBpAEFXy12QkInDctYnkjkkEmlbig0HkOmDlCzHPN5yq9heTHGj2QJ7rLIBFoK7cF7GzLNc51qXLhWB93i2j0c+lypxLe3XSpCepNg2tlnvsqVVL2QzVPvSTvG7GY9aBELOncfwq9lARknq3IZNtWivH7vutXKiwHnjmgvVu02ha4uYurY/n58EK20wpbyzTmgbMqSvjhyMKbXLTOJOOXOBqfukHSxzHs05AhxJVIdJ0kbLijqUrT37+bxAAMbO5z+kc+X6Lp6y8S6jv0drVBuYjIox2zE3PTQbfNvAKPzQLq6NX1t9rsh4u1Rx+euef+8N7vM98w+l/WiLDqHkoP8f+vqyP2/sh64OkxUh3NTqXv10B4DUKqITomuj0+vDqhFl77OTUkAmw=
+    secure: vYv6EqcfqTrjQrePGE8N2yh8hzV0Pqmb2FtP4svxVlMd/l8LwlrllSvjlLGS5yPgTk9xdG+79CVKv0JbKNO9q4RojAm182fkeTb5NlfRtHlnI2hpgQk65Xqk3MrKieSRgW5YZ4DToqfJuW5sS1f/d5tk1rYmfM6QrcktrOWXamtLzyJLj8EdbPtA+8ha+t77P/JmWxvTgF5XlwRYDHhH4W6OpPvmPSY7Qgv0H2toFZdS/20KrQCPDJgAnW5Alu0yCBfjT4WVdFyTLb3x2vkjOtkpYvOfLxeDSguwQMM4rRh+7C6dRGOjyxiwDlN12X9su4rWwHId0Tovq/GCWs/u41CS6QdMIrv10ZHE4x/BTgAb3kyyVMe8CXLIOC5eU/zo2jBmYgMxUG+g+h1Rjc5JI5aXNKfY67DNcNxJc3aK7qFO1GbOT2s+k8GrkmgDczORg8TCtpXd3+0key5o4uYqEmeu7EAb4vDBu1Qgjj+O3i3AiV7ysb4WyM6oDTWLkyq3WCFG01gopoBqkzH+B5yVQHuEYr6aYefNv9mdVLyONJuPZkoRII0R2p602R6OE5XJZALQHiR2Rkb9xMydbw/wrSBTgjkLuZWT6kMOhrbDtX0dP0cWTSl2u3pEFG3uIX+avgjqjQJvcd/p4v6Ay6oRtc2TOJUAou+G7UzUjc4ouno=
   on:
     tags: true
     repo: mrichar1/jsonapi-vuex

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ this.$store.dispatch('jv/getRelated', customRels).then((data) => {
 
 ### Getters
 
-There are 2 getters available. `get` and `status`.
+There are 3 getters available. `get`, `getRelated` and `status`.
 
 #### get
 
@@ -399,6 +399,16 @@ this.$store.getters['jv/get']('widget', '$[?(@.color=="red")]')
 // Note that filters can create impossible conditions
 // The following will return empty, as widget 1 is not red
 this.$store.getters['jv/get']('widget/1', '$[?(@.color=="red")]')
+```
+
+#### getRelated
+
+getRelated returns the relations of the specified resource. The resource is specified by either a string, or by a normalized resource object (as in `jv/get`). The getter returns an object with each of the resource's relationships as a key. The resources inside the objects `relationships`JSON-API key are mapped to a `jv/get` getter. This means that the resources can be retrieved from the result of `getRelated` once they are loaded into the store (with the `getRelated` action). If the resources are not loaded into the store yet, only the keys of the related resources will be returned.
+
+For example, to get all widgets related to the widget with id 1:
+
+```js
+this.$store.getters['jv/getRelated']('widget/1')['widgets']
 ```
 
 #### status

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "webpack": "^4.39.3"
   },
   "name": "jsonapi-vuex",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Access restructured JSONAPI data from a Vuex Store.",
   "keywords": [
     "vue",

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -413,17 +413,19 @@ const getters = () => {
           const relations = get(parent, [jvtag, 'relationships', rel], {})
           let relationsData = {}
           let data = {}
-          if (!Array.isArray(relations.data)) {
-            data[relations.data.id] = getters.get(
-              [relations.data.type, relations.data.id].join('/')
-            )
-            Object.assign(relationsData, data)
-          } else {
-            for (let relation of relations.data) {
-              data[relation.id] = getters.get(
-                [relation.type, relation.id].join('/')
+          if (relations.data) {
+            if (!Array.isArray(relations.data)) {
+              data[relations.data.id] = getters.get(
+                [relations.data.type, relations.data.id].join('/')
               )
               Object.assign(relationsData, data)
+            } else {
+              for (let relation of relations.data) {
+                data[relation.id] = getters.get(
+                  [relation.type, relation.id].join('/')
+                )
+                Object.assign(relationsData, data)
+              }
             }
           }
           return relationsData

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -571,7 +571,7 @@ const checkAndFollowRelationships = (state, getters, records, seenState) => {
 }
 
 // Follow relationships and expand them into _jv/rels
-const followRelationships = (state, getters, record, seenState) => {
+const followRelationships = (state, getters, record, seenState = {}) => {
   // Copy item before modifying
   const data = cloneDeep(record)
 

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -404,6 +404,33 @@ const getters = () => {
       }
       return result
     },
+    getRelated: (state, getters) => (data) => {
+      let parent
+      const [type, id, rel] = getTypeId(data)
+      if (type in state) {
+        if (hasProperty(state[type], id)) {
+          parent = state[type][id]
+          const relations = get(parent, [jvtag, 'relationships', rel], {})
+          let relationsData = {}
+          let data = {}
+          if (!Array.isArray(relations.data)) {
+            data[relations.data.id] = getters.get(
+              [relations.data.type, relations.data.id].join('/')
+            )
+            Object.assign(relationsData, data)
+          } else {
+            for (let relation of relations.data) {
+              data[relation.id] = getters.get(
+                [relation.type, relation.id].join('/')
+              )
+              Object.assign(relationsData, data)
+            }
+          }
+          return relationsData
+        }
+      }
+      return {}
+    },
     status: (state) => (id) => {
       // If id is an object (promise), extract id
       if (typeof id === 'object') {

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -404,25 +404,24 @@ const getters = () => {
       if (type in state) {
         if (hasProperty(state[type], id)) {
           parent = state[type][id]
-          const relations = get(parent, [jvtag, 'relationships', rel], {})
+          let relations = get(parent, [jvtag, 'relationships', rel, 'data'], {})
           let relationsData = {}
           let data = {}
-          if (relations.data) {
-            if (!Array.isArray(relations.data)) {
-              data[relations.data.id] = getters.get(
-                [relations.data.type, relations.data.id].join('/')
-              )
+          if (relations) {
+            relations = Array.from(relations)
+            let relType
+            let relId
+            for (let relation of relations) {
+              relType = relation['type']
+              relId = relation['id']
+              data[relations['id']] = getters.get(`${relType}/${relId}`)
+
               Object.assign(relationsData, data)
-            } else {
-              for (let relation of relations.data) {
-                data[relation.id] = getters.get(
-                  [relation.type, relation.id].join('/')
-                )
-                Object.assign(relationsData, data)
-              }
             }
           }
-          return relationsData
+          return Array.isArray(relations)
+            ? relationsData
+            : relationsData[Object.keys(relationsData)[0]]
         }
       }
       return {}

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -417,16 +417,13 @@ const getters = () => {
                 : Array.of(relations)) {
                 relType = relation['type']
                 relId = relation['id']
+                let getter = getters.get(`${relType}/${relId}`)
                 Object.defineProperty(relationshipsData[relationship], relId, {
-                  // this works:
-                  value: getters.get(`${relType}/${relId}`),
-                  // // this does not:
-                  // get() {
-                  //   return getters.get(`${relType}/${relId}`)
-                  // },
+                  get() {
+                    return getter
+                  },
                   enumerable: true,
                 })
-                // console.log(JSON.parse(JSON.stringify(relationshipsData)))
               }
             }
           }

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -399,13 +399,10 @@ const getters = () => {
       return result
     },
     getRelated: (state, getters) => (data, seen) => {
-      let parent
       const [type, id] = getTypeId(data)
-      if (type in state) {
-        if (hasProperty(state[type], id)) {
-          parent = state[type][id]
-          return getRelationships(getters, parent, seen)
-        }
+      let parent = get(state, [type, id])
+      if (parent) {
+        return getRelationships(getters, parent, seen)
       }
       return {}
     },

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -417,13 +417,18 @@ const getters = () => {
                 : Array.of(relations)) {
                 relType = relation['type']
                 relId = relation['id']
-                let getter = getters.get(`${relType}/${relId}`)
-                Object.defineProperty(relationshipsData[relationship], relId, {
+                let relationData = {}
+
+                Object.defineProperty(relationData, relId, {
                   get() {
-                    return getter
+                    return getters.get(`${relType}/${relId}`)
                   },
                   enumerable: true,
                 })
+                relationshipsData[relationship] = {
+                  ...relationshipsData[relationship],
+                  ...relationData,
+                }
               }
             }
           }

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -398,7 +398,7 @@ const getters = () => {
       }
       return result
     },
-    getRelated: (state, getters) => (data, seen = []) => {
+    getRelated: (state, getters) => (data, seen) => {
       let parent
       const [type, id] = getTypeId(data)
       if (type in state) {
@@ -444,9 +444,9 @@ const getRelationships = (getters, parent, seen) => {
   let relationships = get(parent, [jvtag, 'relationships'], {})
   let relationshipsData = {}
   for (let relName of Object.keys(relationships)) {
-    let relations = get(relationships, [relName, 'data'], {})
+    let relations = get(relationships, [relName, 'data'])
     relationshipsData[relName] = {}
-    if (relations && Object.keys(relations).length) {
+    if (relations) {
       let isItem = !Array.isArray(relations)
       let relationsData = {}
 
@@ -651,7 +651,6 @@ const followRelationships = (state, getters, record, seen = []) => {
     data[key] = record[key]
   }
 
-  // let [type, id] = getTypeId(data)
   let relationships = getRelationships(getters, data, seen)
   Object.defineProperties(data, Object.getOwnPropertyDescriptors(relationships))
 

--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -440,7 +440,7 @@ const jsonapiModule = (api, conf = {}) => {
 
 // Helper methods
 
-const getRelationships = (getters, parent, seen) => {
+const getRelationships = (getters, parent, seen = []) => {
   let relationships = get(parent, [jvtag, 'relationships'], {})
   let relationshipsData = {}
   for (let relName of Object.keys(relationships)) {
@@ -641,15 +641,13 @@ const checkAndFollowRelationships = (state, getters, records, seen) => {
 }
 
 // Follow relationships and expand them into _jv/rels
-const followRelationships = (state, getters, record, seen = []) => {
+const followRelationships = (state, getters, record, seen) => {
   // Make a shallow copy of the object's keys (by reference - preserve getters).
   // We can't add rels to the original object, otherwise Vue's watchers
   // spot the potential loop and throw an error
   let data = {}
-  // Use entries() as we need to iterate the values to get the 'real' record
-  for (let [key] of Object.entries(record)) {
-    data[key] = record[key]
-  }
+
+  Object.defineProperties(data, Object.getOwnPropertyDescriptors(record))
 
   let relationships = getRelationships(getters, data, seen)
   Object.defineProperties(data, Object.getOwnPropertyDescriptors(relationships))


### PR DESCRIPTION
https://github.com/mrichar1/jsonapi-vuex/issues/85
Using the `rels` object works, but when the parent is empty this leads to 'property is undefined' errors. Instead of handling the errors every time in the application, I think there should be a direct way to get the resources which are defined in the `relationships` of a parent. If the parent or relationship does not exist or is not loaded yet, it will simply return an empty result instead of throwing errors. This will make it easier to load related objects.

This is just a basic approach and still open to improvements.