### PR TITLE
Improve logic/efficiency of JvHelpers

### DIFF
--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -500,10 +500,8 @@ const addJvHelpers = (obj) => {
   Object.defineProperty(obj[jvtag], 'rels', {
     get() {
       const rel = {}
-      for (let [key, val] of Object.entries(obj)) {
-        if (this.isRel(key)) {
-          rel[key] = val
-        }
+      for (let key of Object.keys(get(obj, [jvtag, 'relationships'], {}))) {
+        rel[key] = obj[key]
       }
       return rel
     },
@@ -514,7 +512,7 @@ const addJvHelpers = (obj) => {
     get() {
       const att = {}
       for (let [key, val] of Object.entries(obj)) {
-        if (key !== jvtag && !this.isRel(key)) {
+        if (this.isAttr(key)) {
           att[key] = val
         }
       }


### PR DESCRIPTION
- for 'rels' only iterate relationships, not all attrs
- for 'attrs' re-use isAttr() test logic
- fixes #94

(There's a very slight inefficiency in `attrs` in that it now calls `hasProperty` on the key, even though we know it exists since we're iterating over the object's keys... however this is offset by the benefit of reusing `isAttr` which makes things DRY and avoids later bugs due to code divergence.)