### PR TITLE
Handle empty to-one (null) relationships

### DIFF
--- a/src/jsonapi-vuex.js
+++ b/src/jsonapi-vuex.js
@@ -507,7 +507,12 @@ const _copy = (data) => {
   // Recursive object copying function (for 'simple' objects)
   let out = Array.isArray(data) ? [] : {}
   for (let key in data) {
-    out[key] = typeof data[key] === 'object' ? _copy(data[key]) : data[key]
+    // null is typeof 'object'
+    if (typeof data[key] === 'object' && data[key] !== null) {
+      out[key] = _copy(data[key])
+    } else {
+      out[key] = data[key]
+    }
   }
   return out
 }

--- a/tests/unit/actions/getRelated.spec.js
+++ b/tests/unit/actions/getRelated.spec.js
@@ -216,6 +216,14 @@ describe('getRelated', function() {
     }
   })
 
+  it('Should handle data: null (empty to-one rels)', async function() {
+    jsonWidget1['relationships']['widgets']['data'] = null
+    delete jsonWidget1['relationships']['widgets']['links']
+    this.mockApi.onGet().replyOnce(200, { data: jsonWidget1 })
+    let res = await jsonapiModule.actions.getRelated(stubContext, 'widget/1')
+    expect(res).to.deep.equal({ widgets: {} })
+  })
+
   it('Should handle API errors (in the data)', async function() {
     this.mockApi
       .onGet()

--- a/tests/unit/jsonapi-vuex.spec.js
+++ b/tests/unit/jsonapi-vuex.spec.js
@@ -269,6 +269,7 @@ describe('jsonapi-vuex tests', function() {
         // Create a simple object with a variety of content
         const obj = {
           undef: undefined,
+          null: null,
           func: function() {},
           string: 'word',
           number: 10,


### PR DESCRIPTION
Updates code in `getRelated` action and `_copy` to deal with `null`. Fixes #102 