### PR TITLE
Don't url-encode type/id for getters.

### DIFF
--- a/src/getters.js
+++ b/src/getters.js
@@ -32,7 +32,7 @@ export default (conf) => {
         // No data arg - return whole state object
         result = state
       } else {
-        const [type, id] = utils.getTypeId(data)
+        const [type, id] = utils.getTypeId(data, false)
 
         if (utils.hasProperty(state, type)) {
           if (id) {
@@ -76,7 +76,7 @@ export default (conf) => {
      * @return {object} Restructured representation of the record(s)
      */
     getRelated: (state, getters) => (data, seen) => {
-      const [type, id] = utils.getTypeId(data)
+      const [type, id] = utils.getTypeId(data, false)
       if (!type || !id) {
         throw 'No type/id specified'
       }

--- a/src/lib.js
+++ b/src/lib.js
@@ -300,9 +300,10 @@ const Utils = class {
    * Get the type, id and relationships from a restructured object
    * @memberof module:jsonapi-vuex.utils
    * @param {object} data - A restructured object
+   * @param {boolean} encode=true - url-encode the returned values
    * @return {array} An array (optionally) containing type, id and rels
    */
-  getTypeId(data) {
+  getTypeId(data, encode = true) {
     let type, id, rel
     if (typeof data === 'string') {
       ;[type, id, rel] = data.replace(/^\//, '').split('/')
@@ -310,12 +311,13 @@ const Utils = class {
       ;({ type, id } = data[this.jvtag])
     }
 
+    let result = [type, id, rel]
     // Spec: The values of the id and type members MUST be strings.
     // uri encode to prevent mis-interpretation as url parts.
-    // Strip any empty strings (falsey items)
-    return [type && encodeURIComponent(type), id && encodeURIComponent(id), rel && encodeURIComponent(rel)].filter(
-      Boolean
-    )
+    if (encode) {
+      result = [type && encodeURIComponent(type), id && encodeURIComponent(id), rel && encodeURIComponent(rel)]
+    }
+    return result.filter(Boolean)
   }
 
   /**

--- a/tests/unit/jsonapi-vuex.spec.js
+++ b/tests/unit/jsonapi-vuex.spec.js
@@ -44,6 +44,7 @@ let jm,
   normRecordRels,
   storeWidget1,
   storeWidget1Update,
+  storeWidgetSpecialChars,
   storeRecord
 
 // Mock up a fake axios-like api instance
@@ -103,6 +104,12 @@ beforeEach(function () {
     },
   }
   storeRecord = createStoreRecord()
+  // Create a widget where id contains special chars
+  storeWidgetSpecialChars = {
+    widget: {
+      '# ?': storeWidget1['widget']['1'],
+    },
+  }
 })
 
 afterEach(function () {})
@@ -327,6 +334,15 @@ describe('jsonapi-vuex tests', function () {
           },
         }
         expect(utils.getTypeId(urlWidget)).to.deep.equal(['%2F%23', '%3F%20%26'])
+      })
+      it('should not uri encode type and/or id if encode=false', function () {
+        const urlWidget = {
+          _jv: {
+            type: '/#',
+            id: '? &',
+          },
+        }
+        expect(utils.getTypeId(urlWidget, false)).to.deep.equal(['/#', '? &'])
       })
     })
 
@@ -612,6 +628,11 @@ describe('jsonapi-vuex tests', function () {
       it('should accept a string path to object', function () {
         const { get } = jm.getters
         const result = get(storeWidget1)('widget/1')
+        expect(result).to.deep.equal(normWidget1)
+      })
+      it('should accept a string path with special chars without url-encoding', function () {
+        const { get } = jm.getters
+        const result = get(storeWidgetSpecialChars)('widget/# ?')
         expect(result).to.deep.equal(normWidget1)
       })
       it('should filter results using jsonpath, returning a single item', function () {


### PR DESCRIPTION
Make url-encoding optional in `utils.getTypeId` and then disable it when called from getters. Fixes #164 